### PR TITLE
Remove Control FSM from Instruction Decode

### DIFF
--- a/src/Instruction_Decode/Instruction_Decode.v
+++ b/src/Instruction_Decode/Instruction_Decode.v
@@ -113,26 +113,6 @@ module Instruction_Decode(
 		endcase
 	end
 
-	//instantiate state machine module
-	ControlFSM instanceFSM(
-		
-		.opcode(instr[6:0]),
-		.clk(clk),
-		.reset(reset),
-		.AdrSrc(AdrSrc),
-		.IRWrite(IRWrite),
-		.RegWrite(RegWrite),
-		.PCUpdate(PCUpdate),
-		.MemWrite(MemWrite),
-		.Branch(Branch),
-		.ALUSrcA(ALUSrcA),
-		.ALUSrcB(ALUSrcB),
-		.ALUOp(ALUOp),
-		.ResultSrc(ResultSrc),
-		.FSMState(state)
-	
-	);
-
 	//Instantiate ALU Decoder module
 	
 	ALUdecoder instanceALUDec(


### PR DESCRIPTION
Remove instantiated Control FSM from Instruction Decode, as FSM is now instantiated in top level module