### PR TITLE
Run CI on main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: risc-v CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
CI is currently only running on pull requests and not on our main branch.