### PR TITLE
Fix github actions on main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}
+      image-primary-tag: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
       image-digest: ${{ steps.build.outputs.digest }}
 
     steps:
@@ -62,7 +63,7 @@ jobs:
     needs: build_ci_image
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.build_ci_image.outputs.image-tag }}
+      image: ${{ needs.build_ci_image.outputs.image-primary-tag }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Looks like gha can't properly pull the image:
<img width="1205" height="413" alt="image" src="https://github.com/user-attachments/assets/84317033-eedf-4b66-a909-eb773a361594" />

I think this is because the image on `main` gets double-tagged (both `ci-latest` and `ci-branch-main`)