### PR TITLE
Move RF testbench to `test/` and fix `lw`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ new_tb:
 
 build_tb: $(TB_VVPS) $(TB_SRCS) $(TB_UTILS)
 
-run_tb: $(TB_VVPS)
+run_tb: build_tb
 	@failed=0;                                                \
 	for tb in $(TB_VVPS); do                                  \
 		echo "Running $$tb...";                                 \

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ new_tb:
 	fi
 	m4 -D M4__TB_NAME="$(name)_tb" test/tb_template.sv.m4 > test/$(name)_tb.sv
 
-build_tb: $(TB_VVPS)
+build_tb: $(TB_VVPS) $(TB_SRCS) $(TB_UTILS)
 
 run_tb: $(TB_VVPS)
 	@failed=0;                                                \

--- a/src/ControlFSM.sv
+++ b/src/ControlFSM.sv
@@ -101,6 +101,7 @@ module ControlFSM(
     Branch <= 1'b0;
     pc_src <= 1'b0;
     PCUpdate <= 1'b0;
+    IRWrite <= 1'b0;
 
 		FSMState <= current_state;
 
@@ -110,6 +111,7 @@ module ControlFSM(
 
 				AdrSrc <= ADR_SRC__PC;
 				IRWrite <= 1'b1;
+        PCUpdate <= 1'b1;
 
 			end
 

--- a/src/top.v
+++ b/src/top.v
@@ -12,6 +12,7 @@ module top ( input wire clk
 
   addr_t   pc_cur;
   addr_t   memory_address;
+  data_t   memory_data;
   data_t   data;
   instr_t  instruction;
   opcode_t opcode;
@@ -87,11 +88,21 @@ module top ( input wire clk
     , .CLK ( clk            )
 
     // outputs
-    , .RD  ( data           )
+    , .RD  ( memory_data    )
     );
 
+  always @(posedge clk) begin
+    if (cfsm__ir_write) begin
+      instruction <= memory_data;
+    end
+  end
+
+  always @(posedge clk) begin
+    data <= memory_data;
+  end
+
   Instruction_Decode instruction_decode
-    ( .instr           ( data             )
+    ( .instr           ( instruction      )
     , .clk             ( clk              )
     , .reset           ( reset            )
     , .ResultData      ( result           )

--- a/test/lw_tb.sv
+++ b/test/lw_tb.sv
@@ -25,16 +25,18 @@ module lw_tb;
   initial begin
     reset <= `TRUE;
 
-    // set up instructions and data memory
+    // set up instructions and data memory; M array uses word addressing, hence the indices there
+    // are 4 times smaller than the actual addresses corresponding to the beginning to the
+    // corresponding word
     uut.memory.M[ 0] = 32'h00012083; // lw x1, 0(x2)
-    uut.memory.M[ 4] = 32'h00412083; // lw x1, 4(x2)
-    uut.memory.M[ 8] = 32'hff812083; // lw x1, -8(x2)
-    uut.memory.M[34] = 32'hbadab00f; // have some data at address 34
-    uut.memory.M[42] = 32'hdeadbeef; // have some data at address 42
-    uut.memory.M[46] = 32'hcafebabe; // have some data at address 46
+    uut.memory.M[ 1] = 32'h00412083; // lw x1, 4(x2)
+    uut.memory.M[ 2] = 32'hff812083; // lw x1, -8(x2)
+    uut.memory.M[40] = 32'hbadab00f; // have some data at address 0xa0
+    uut.memory.M[42] = 32'hdeadbeef; // have some data at address 0xa8
+    uut.memory.M[43] = 32'hcafebabe; // have some data at address 0xac
 
     // set up register file
-    uut.instruction_decode.instanceRegFile.RFMem[2] = 42; // x2 = 42
+    uut.instruction_decode.instanceRegFile.RFMem[2] = 32'ha8; // x2 = 42 * 4 = 168 = 0xa8
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
@@ -49,15 +51,15 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMADR);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
-    `assert_equal(uut.alu.a, 42)
+    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.alu.a, 32'ha8)
     `assert_equal(uut.alu.b, 0)
-    `assert_equal(uut.alu.out, 42)
+    `assert_equal(uut.alu.out, 32'ha8)
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMREAD);
 
-    `assert_equal(uut.result, 42)
-    `assert_equal(uut.memory_address, 42)
+    `assert_equal(uut.result, 32'ha8)
+    `assert_equal(uut.memory_address, 32'ha8)
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMWB);
 
@@ -67,7 +69,7 @@ module lw_tb;
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
     `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'hdeadbeef)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.fetch.pc_cur, 4) // starting second instruction already
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
@@ -79,15 +81,15 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMADR);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
-    `assert_equal(uut.alu.a, 42)
+    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.alu.a, 32'ha8)
     `assert_equal(uut.alu.b, 4)
-    `assert_equal(uut.alu.out, 46)
+    `assert_equal(uut.alu.out, 32'hac)
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMREAD);
 
-    `assert_equal(uut.result, 46)
-    `assert_equal(uut.memory_address, 46)
+    `assert_equal(uut.result, 32'hac)
+    `assert_equal(uut.memory_address, 32'hac)
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMWB);
 
@@ -97,7 +99,7 @@ module lw_tb;
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
     `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'hcafebabe)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.fetch.pc_cur, 8) // starting third instruction already
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
@@ -109,15 +111,15 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMADR);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
-    `assert_equal(uut.alu.a, 42)
+    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.alu.a, 32'ha8)
     `assert_equal(uut.alu.b, -8)
-    `assert_equal(uut.alu.out, 34)
+    `assert_equal(uut.alu.out, 32'ha0)
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMREAD);
 
-    `assert_equal(uut.result, 34)
-    `assert_equal(uut.memory_address, 34)
+    `assert_equal(uut.result, 32'ha0)
+    `assert_equal(uut.memory_address, 32'ha0)
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMWB);
 
@@ -127,9 +129,10 @@ module lw_tb;
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
     `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'hbadab00f)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.fetch.pc_cur, 12)
 
+    $finish;
   end
 
   `SETUP_VCD_DUMP(lw_tb)

--- a/test/rf_tb.sv
+++ b/test/rf_tb.sv
@@ -28,10 +28,7 @@ module rf_tb;
   );
 
   //Clock generation
-  initial begin
-    clk = 0;
-    forever #5 clk = ~clk;
-  end
+  always #5 clk = ~clk;
 
   initial begin
     $display("Starting Register File Testbench...");

--- a/test/rf_tb.sv
+++ b/test/rf_tb.sv
@@ -1,6 +1,8 @@
 `timescale 1ns/1ps
 
-module tb_registerFile;
+`include "test/utils.svh"
+
+module rf_tb;
 
   //DUT inputs
   logic [4:0] Addr1, Addr2, Addr3;
@@ -26,7 +28,10 @@ module tb_registerFile;
   );
 
   //Clock generation
-  always #5 clk = ~clk;
+  initial begin
+    clk = 0;
+    forever #5 clk = ~clk;
+  end
 
   initial begin
     $display("Starting Register File Testbench...");
@@ -46,7 +51,7 @@ module tb_registerFile;
     //set Addr1 = 5 and Addr2 = 10 to read from registers 5 and 10
     Addr1 = 5;
     Addr2 = 10;
-    Addr3 = 0; 
+    Addr3 = 0;
     dataIn = 0;
     regWrite = 0;
 
@@ -61,33 +66,28 @@ module tb_registerFile;
     Addr3 = 15;
     dataIn = 32'h12345678;
     regWrite = 1;
- 
+
     @(posedge clk); //wait one clock cycle
 
     #1; //wait for written data to stabilize
     regWrite = 0; //de-assert write
     assert(dut.RFMem[15] == 32'h12345678) else $fatal(1, "WRITE FAILED: current reg 15 output: %h; expected reg 15 output: 12345678", dut.RFMem[15]);
     $display("PASS: Write to register 15 verified. current reg 15 output: %h; expected reg 15 output: 12345678", dut.RFMem[15]);
-	 
+
 	 //CASE 3 - Write to reg 0
 	 Addr3 = 0;
 	 dataIn = 32'h12345678;
-	 
+
 	 @(posedge clk); //wait one clock cycle
-	 
+
     #1; //wait for written data to stabilize
     regWrite = 0; //de-assert write
-    assert(dut.RFMem[0] == 0) else $fatal(1, "WRITE FAILED: current reg 0 output: %h; expected reg 0 output: 0", dut.RFMem[0]);	 
+    assert(dut.RFMem[0] == 0) else $fatal(1, "WRITE FAILED: current reg 0 output: %h; expected reg 0 output: 0", dut.RFMem[0]);
     $display("PASS: Write to register 0 verified. current reg 0 output: %h; expected reg 0 output: 0", dut.RFMem[0]);
 
     $finish;
   end
-  
-  initial begin //generate waveform
-	 
-	$dumpfile("RFTB.vcd");
-	$dumpvars(0, tb_registerFile);
-	 
-  end
+
+  `SETUP_VCD_DUMP(rf_tb)
 
 endmodule


### PR DESCRIPTION
Moved register file test branch to `test/` folder as per #39 ; however this surfaced another issue -- the `lw` instruction was not implemented correctly though its testbench was passing because the `$finish` in the RF testbench would be invoked as part of every testbench, so only the first few assertions in the test benches were actually verified and the rest would be silently skipped.

My fix was primarily around implementing the `instruction` and `data` registers that I overlooked in the original implementation:

<img width="162" height="384" alt="image" src="https://github.com/user-attachments/assets/f380544a-2424-42c0-94df-ee07c5d07394" />

Another issue was that I overlooked the difference between word-addressing and byte-addressing in the MA module, so I fixed that as well.