### PR TITLE
Take `src/` into account when building testbenches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ new_tb:
 	fi
 	m4 -D M4__TB_NAME="$(name)_tb" test/tb_template.sv.m4 > test/$(name)_tb.sv
 
-build_tb: $(TB_VVPS) $(TB_SRCS) $(TB_UTILS)
+build_tb: $(TB_VVPS) $(TB_SRCS) $(TB_UTILS) $(SRCS)
 
 run_tb: build_tb
 	@failed=0;                                                \


### PR DESCRIPTION
Just a quick fix for `Makefile`