### PR TITLE
Fix `regWrite` signal

### DIFF
--- a/src/ControlFSM.sv
+++ b/src/ControlFSM.sv
@@ -116,6 +116,7 @@ module ControlFSM(
     PCUpdate <= 1'b0;
     IRWrite <= 1'b0;
     MemWrite <= 1'b0;
+    RegWrite <= 1'b0;
 
 		FSMState <= current_state;
 


### PR DESCRIPTION
This signal was not properly de-asserted after its corresponding state was completed.