### PR TITLE
Fixing RISCOF test cases add/sub/and/xor/or/slli/sll/sra/srl

### DIFF
--- a/src/ControlFSM.sv
+++ b/src/ControlFSM.sv
@@ -116,6 +116,7 @@ module ControlFSM(
     PCUpdate <= 1'b0;
     IRWrite <= 1'b0;
     MemWrite <= 1'b0;
+	RegWrite <= 1'b0;
 
 		FSMState <= current_state;
 
@@ -126,7 +127,6 @@ module ControlFSM(
 				AdrSrc <= ADR_SRC__PC;
 				IRWrite <= 1'b1;
        			PCUpdate <= 1'b1;
-				RegWrite <= 1'b0;
 
 			end
 
@@ -176,7 +176,7 @@ module ControlFSM(
 				ALUSrcB <= ALU_SRC_B__4;
 				ALUOp <= 2'b00;
 				ResultSrc <= RESULT_SRC__ALU_OUT;
-        PCUpdate <= 1'b1;
+        		PCUpdate <= 1'b1;
 
 			end
 
@@ -195,8 +195,8 @@ module ControlFSM(
 				ALUOp <= 2'b01;
 				ResultSrc <= RESULT_SRC__ALU_OUT;
 				Branch <= 1'b1;
-        pc_src <= zero_flag ? PC_SRC__JUMP : PC_SRC__INCREMENT;
-        PCUpdate <= 1'b1;
+        		pc_src <= zero_flag ? PC_SRC__JUMP : PC_SRC__INCREMENT;
+        		PCUpdate <= 1'b1;
 
 			end
 


### PR DESCRIPTION
Added regWrite <= 1'b0 to ControlFSM.sv to set it low by default to prevent overwriting of registers in the Fetch stage.