### PR TITLE
Extracted RF module and tested with RISCOF

### DIFF
--- a/src/Instruction_Decode/Instruction_Decode.v
+++ b/src/Instruction_Decode/Instruction_Decode.v
@@ -4,21 +4,17 @@
 module Instruction_Decode(
 
 	input wire [31:0] instr,
-	input wire clk,
-	input wire reset,
-	input wire [31:0] ResultData,
-  input wire reg_write,
-  output opcode_t opcode,
+  	output opcode_t opcode,
 	output wire [3:0] ALUControl,
-	output wire [31:0] baseAddr,
-	output wire [31:0] writeData,
-  output imm_t imm_ext
+ 	output imm_t imm_ext,
+	output reg [4:0] rd,
+	output reg [4:0] rs1, 
+	output reg [4:0] rs2
 );
 
 	alu_op_t alu_op;
 	reg [2:0] funct3;
 	reg [6:0] funct7;
-	reg [4:0] rd, rs1, rs2;
 	wire [3:0] state;
 
   assign opcode = instr[6:0];
@@ -140,21 +136,6 @@ module Instruction_Decode(
 		.funct7(funct7),
 		.alu_op(alu_op),
 		.alu_control(ALUControl)
-
-	);
-
-	//instantiate Register File module
-	registerFile instanceRegFile(
-
-		.Addr1(rs1),
-		.Addr2(rs2),
-		.Addr3(rd),
-		.clk(clk),
-		.reset(reset),
-		.regWrite(reg_write),
-		.dataIn(ResultData),
-		.baseAddr(baseAddr),
-		.writeData(writeData)
 
 	);
 

--- a/src/Instruction_Decode/Instruction_Decode.v
+++ b/src/Instruction_Decode/Instruction_Decode.v
@@ -7,6 +7,7 @@ module Instruction_Decode(
   	output opcode_t opcode,
 	output wire [3:0] ALUControl,
  	output imm_t imm_ext,
+	output reg [2:0] funct3,
 	output reg [4:0] rd,
 	output reg [4:0] rs1, 
 	output reg [4:0] rs2
@@ -114,7 +115,7 @@ module Instruction_Decode(
 	end
 
 	// case statement for choosing 32-bit immediate format; based on opcode
-  // this is essentially the extend module of the processor
+    // this is essentially the extend module of the processor
 	always@(*) begin
 		case(opcode)
 			IType_logic : imm_ext = {{20{instr[31]}}, instr[31:20]};

--- a/src/top.v
+++ b/src/top.v
@@ -42,8 +42,8 @@ module top #( parameter MEM_SIZE = 1024 )
   wire [3:0] __tmp_ALUControl;
   wire [1:0] __tmp_ResultSrc;
   wire [3:0] __tmp_FSMState;
-  logic [31:0] dataA
-			 ,dataB;
+  data_t     dataA, dataB;
+  reg  [4:0] rd, rs1, rs2;
 
   ControlFSM control_fsm
     ( .opcode    ( opcode           )
@@ -107,16 +107,25 @@ module top #( parameter MEM_SIZE = 1024 )
 
   Instruction_Decode instruction_decode
     ( .instr           ( instruction      )
-    , .clk             ( clk              )
-    , .reset           ( reset            )
-    , .ResultData      ( result           )
-    , .reg_write       ( cfsm__reg_write  )
     , .opcode          ( opcode           )
     , .ALUControl      ( __tmp_ALUControl )
-    , .baseAddr        ( rd1              )
-    , .writeData       ( rd2              )
     , .imm_ext         ( imm_ext          )
+    , .rd              ( rd               )
+    , .rs1             ( rs1              )
+    , .rs2             ( rs2              )
     );
+
+  registerFile RegFile
+    ( .Addr1(rs1)
+    , .Addr2(rs2)
+    , .Addr3(rd)
+    , .clk(clk)
+    , .reset(reset)
+    , .regWrite(cfsm__reg_write)
+    , .dataIn(result)
+    , .baseAddr(rd1)
+    , .writeData(rd2)
+	  );
 
   ALU alu
     ( .a              ( alu_input_a      )
@@ -160,8 +169,8 @@ module top #( parameter MEM_SIZE = 1024 )
   end
 
   always @(posedge clk) begin
-	dataA <= rd1;
-	dataB <= rd2;
+	  dataA <= rd1;
+	  dataB <= rd2;
   end
 
 endmodule

--- a/src/top.v
+++ b/src/top.v
@@ -166,15 +166,15 @@ module top #( parameter MEM_SIZE = 1024 )
     );
 
   registerFile RegFile
-    ( .Addr1(rs1)
-    , .Addr2(rs2)
-    , .Addr3(rd)
-    , .clk(clk)
-    , .reset(reset)
-    , .regWrite(cfsm__reg_write)
-    , .dataIn(result)
-    , .baseAddr(rd1)
-    , .writeData(rd2)
+    ( .Addr1           ( rs1              )
+    , .Addr2           ( rs2              )
+    , .Addr3           ( rd               )
+    , .clk             ( clk              )
+    , .reset           ( reset            )
+    , .regWrite        ( cfsm__reg_write  )
+    , .dataIn          ( result           )
+    , .baseAddr        ( rd1              )
+    , .writeData       ( rd2              )
 	  );
 
   ALU alu

--- a/test/addi_tb.sv
+++ b/test/addi_tb.sv
@@ -31,8 +31,8 @@ module addi_tb;
     uut.memory.M[ 2] = 32'hff810093; // addi x1, x2, -8
 
     // Set up register file
-    uut.instruction_decode.instanceRegFile.RFMem[1] = 0; // x1 = 0
-    uut.instruction_decode.instanceRegFile.RFMem[2] = 42; // x2 = 42
+    uut.RegFile.RFMem[1] = 0; // x1 = 0
+    uut.RegFile.RFMem[2] = 42; // x2 = 42
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
@@ -53,7 +53,7 @@ module addi_tb;
     wait_till_next_cfsm_state(uut.control_fsm.ALUWB);
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 42)
+    `assert_equal(uut.RegFile.RFMem[1], 42)
     `assert_equal(uut.fetch.pc_cur, 4)
 
     // --- Instruction 2: addi x1, x2, 4 ---
@@ -66,7 +66,7 @@ module addi_tb;
     wait_till_next_cfsm_state(uut.control_fsm.ALUWB);
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 46)
+    `assert_equal(uut.RegFile.RFMem[1], 46)
     `assert_equal(uut.fetch.pc_cur, 8)
 
     // --- Instruction 3: addi x1, x2, -8 ---
@@ -79,11 +79,11 @@ module addi_tb;
     wait_till_next_cfsm_state(uut.control_fsm.ALUWB);
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 34)
+    `assert_equal(uut.RegFile.RFMem[1], 34)
 
     // Final assertions
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 34)
+    `assert_equal(uut.RegFile.RFMem[2], 42)
+    `assert_equal(uut.RegFile.RFMem[1], 34)
 
     $finish;
   end

--- a/test/auipc_tb.sv
+++ b/test/auipc_tb.sv
@@ -70,7 +70,7 @@ module auipc_tb;
     //Exe lui x2, 200
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'h00014000 + tb_pc_old)
+    `assert_equal(uut.RegFile.RFMem[1], 32'h00014000 + tb_pc_old)
     //x1 at this moment should be updated
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
@@ -94,7 +94,7 @@ module auipc_tb;
     //Exe lui x3, 1023
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'h000c8000 + tb_pc_old)
+    `assert_equal(uut.RegFile.RFMem[2], 32'h000c8000 + tb_pc_old)
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
 
@@ -116,7 +116,7 @@ module auipc_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[3], 32'h003ff000 + tb_pc_old)
+    `assert_equal(uut.RegFile.RFMem[3], 32'h003ff000 + tb_pc_old)
 
     //If the simulation makes to this point, the simulation passed
 

--- a/test/beq_tb.sv
+++ b/test/beq_tb.sv
@@ -33,7 +33,7 @@ module beq_tb;
     uut.memory.M[0] = 32'hFE420AE3; // beq x4, x4, -0xc
 
     // initialize registers
-    uut.instruction_decode.instanceRegFile.RFMem[5'b00100] = 32'h0000002a; // x4 = 42
+    uut.RegFile.RFMem[5'b00100] = 32'h0000002a; // x4 = 42
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
     reset <= `FALSE;
@@ -65,8 +65,8 @@ module beq_tb;
     reset <= `TRUE;
 
     uut.memory.M[0] = 32'b0000000_00010_00001_000_1000_0_1100011; // beq x1, x2, 0x10
-    uut.instruction_decode.instanceRegFile.RFMem[5'b00001] = 32'h0000002a; // x1 = 42
-    uut.instruction_decode.instanceRegFile.RFMem[5'b00010] = 32'h0000002b; // x2 = 43
+    uut.RegFile.RFMem[5'b00001] = 32'h0000002a; // x1 = 42
+    uut.RegFile.RFMem[5'b00010] = 32'h0000002b; // x2 = 43
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
     reset <= `FALSE;
@@ -96,7 +96,7 @@ module beq_tb;
     reset <= `TRUE;
 
     uut.memory.M[0] = 32'b0100000_00001_00001_000_00001_0110011; // sub x1, x1, x1
-    uut.instruction_decode.instanceRegFile.RFMem[5'b00001] = 32'h00000001; // x1 = 1
+    uut.RegFile.RFMem[5'b00001] = 32'h00000001; // x1 = 1
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
     reset <= `FALSE;

--- a/test/lui_tb.sv
+++ b/test/lui_tb.sv
@@ -68,7 +68,7 @@ module lui_tb;
     //Exe lui x2, 200
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'h00014000)
+    `assert_equal(uut.RegFile.RFMem[1], 32'h00014000)
     //x1 at this moment should be updated
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
@@ -92,7 +92,7 @@ module lui_tb;
     //Exe lui x3, 1023
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'h000c8000)
+    `assert_equal(uut.RegFile.RFMem[2], 32'h000c8000)
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
 
@@ -114,7 +114,7 @@ module lui_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[3], 32'h003ff000)
+    `assert_equal(uut.RegFile.RFMem[3], 32'h003ff000)
 
     //If the simulation makes to this point, the simulation passed
 

--- a/test/lw_tb.sv
+++ b/test/lw_tb.sv
@@ -36,7 +36,7 @@ module lw_tb;
     uut.memory.M[43] = 32'hcafebabe; // have some data at address 0xac
 
     // set up register file
-    uut.instruction_decode.instanceRegFile.RFMem[2] = 32'ha8; // x2 = 42 * 4 = 168 = 0xa8
+    uut.RegFile.RFMem[2] = 32'ha8; // x2 = 42 * 4 = 168 = 0xa8
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
@@ -51,7 +51,7 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMADR);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.RegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.alu.a, 32'ha8)
     `assert_equal(uut.alu.b, 0)
     `assert_equal(uut.alu.out, 32'ha8)
@@ -68,8 +68,8 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'hdeadbeef)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.RegFile.RFMem[1], 32'hdeadbeef)
+    `assert_equal(uut.RegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.fetch.pc_cur, 4) // starting second instruction already
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
@@ -81,7 +81,7 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMADR);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.RegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.alu.a, 32'ha8)
     `assert_equal(uut.alu.b, 4)
     `assert_equal(uut.alu.out, 32'hac)
@@ -98,8 +98,8 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'hcafebabe)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.RegFile.RFMem[1], 32'hcafebabe)
+    `assert_equal(uut.RegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.fetch.pc_cur, 8) // starting third instruction already
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
@@ -111,7 +111,7 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.MEMADR);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.RegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.alu.a, 32'ha8)
     `assert_equal(uut.alu.b, -8)
     `assert_equal(uut.alu.out, 32'ha0)
@@ -128,8 +128,8 @@ module lw_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'hbadab00f)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 32'ha8)
+    `assert_equal(uut.RegFile.RFMem[1], 32'hbadab00f)
+    `assert_equal(uut.RegFile.RFMem[2], 32'ha8)
     `assert_equal(uut.fetch.pc_cur, 12)
 
     $finish;

--- a/test/nop_tb.sv
+++ b/test/nop_tb.sv
@@ -30,7 +30,7 @@ module nop_tb;
         uut.memory.M[0] = 32'h00000013; //NOP instruction - addi x0, x0, 0
 
         // set up register file to a known value
-        uut.instruction_decode.instanceRegFile.RFMem[0] = 32'h01010101; // x0, and it should still be 0 even we try to write it as 0
+        uut.RegFile.RFMem[0] = 32'h01010101; // x0, and it should still be 0 even we try to write it as 0
 
         //wait until reset makes FSM go to fetch state
         wait_till_next_cfsm_state(uut.control_fsm.FETCH);
@@ -52,7 +52,7 @@ module nop_tb;
         wait_till_next_cfsm_state(uut.control_fsm.ALUWB);
 
         wait_till_next_cfsm_state(uut.control_fsm.FETCH);
-        `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[0], 32'h0)
+        `assert_equal(uut.RegFile.RFMem[0], 32'h0)
         `assert_equal(uut.fetch.pc_cur, 4)
 
         $finish;

--- a/test/or_tb.sv
+++ b/test/or_tb.sv
@@ -27,8 +27,8 @@ module or_tb;
 
     uut.memory.M[0] = 32'h003160b3; // or x1,x2,x3 ; x1 = x2 | x3
 
-    uut.instruction_decode.instanceRegFile.RFMem[2] = 32'hf0f0f0f0; // x2
-    uut.instruction_decode.instanceRegFile.RFMem[3] = 32'h0b0b0b0b; // x3
+    uut.RegFile.RFMem[2] = 32'hf0f0f0f0; // x2
+    uut.RegFile.RFMem[3] = 32'h0b0b0b0b; // x3
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
@@ -54,7 +54,7 @@ module or_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 32'hfbfbfbfb)
+    `assert_equal(uut.RegFile.RFMem[1], 32'hfbfbfbfb)
     `assert_equal(uut.fetch.pc_cur, 4)
 
     $finish;

--- a/test/srli_tb.sv
+++ b/test/srli_tb.sv
@@ -32,7 +32,7 @@ module srli_tb;
 
 
     // set up register file
-    uut.instruction_decode.instanceRegFile.RFMem[2] = 42; // x2 = 42; 101010
+    uut.RegFile.RFMem[2] = 42; // x2 = 42; 101010
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
@@ -46,7 +46,7 @@ module srli_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.EXECUTEI);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.RegFile.RFMem[2], 42)
     `assert_equal(uut.alu.a, 42)
     `assert_equal(uut.alu.b, 1)
     `assert_equal(uut.alu.out, 21)
@@ -57,8 +57,8 @@ module srli_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 21)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.RegFile.RFMem[1], 21)
+    `assert_equal(uut.RegFile.RFMem[2], 42)
     `assert_equal(uut.fetch.pc_cur, 4) // starting second instruction already
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
@@ -69,7 +69,7 @@ module srli_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.EXECUTEI);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.RegFile.RFMem[2], 42)
     `assert_equal(uut.alu.a, 42)
     `assert_equal(uut.alu.b, 2)
     `assert_equal(uut.alu.out, 10)
@@ -80,8 +80,8 @@ module srli_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 10)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.RegFile.RFMem[1], 10)
+    `assert_equal(uut.RegFile.RFMem[2], 42)
     `assert_equal(uut.fetch.pc_cur, 8) // starting third instruction already
 
     wait_till_next_cfsm_state(uut.control_fsm.DECODE);
@@ -92,7 +92,7 @@ module srli_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.EXECUTEI);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.RegFile.RFMem[2], 42)
     `assert_equal(uut.alu.a, 42)
     `assert_equal(uut.alu.b, 3)
     `assert_equal(uut.alu.out, 5)
@@ -103,8 +103,8 @@ module srli_tb;
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[1], 5)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[2], 42)
+    `assert_equal(uut.RegFile.RFMem[1], 5)
+    `assert_equal(uut.RegFile.RFMem[2], 42)
     `assert_equal(uut.fetch.pc_cur, 12)
 
     $finish;

--- a/test/sw_tb.sv
+++ b/test/sw_tb.sv
@@ -35,8 +35,8 @@ module sw_tb;
     uut.memory.M[13] = 32'h00000000; // will be written by sw x5, 8(x6)
 
     // set up register file
-    uut.instruction_decode.instanceRegFile.RFMem[6] = 44;    // x6 = 44
-    uut.instruction_decode.instanceRegFile.RFMem[5] = 256;   // x5 = 256
+    uut.RegFile.RFMem[6] = 44;    // x6 = 44
+    uut.RegFile.RFMem[5] = 256;   // x5 = 256
 
     wait_till_next_cfsm_state(uut.control_fsm.FETCH);
 
@@ -98,8 +98,8 @@ module sw_tb;
     `assert_equal(uut.memory.M[11], 256)
     `assert_equal(uut.memory.M[12], 256)
     `assert_equal(uut.memory.M[13], 256)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[5], 256)
-    `assert_equal(uut.instruction_decode.instanceRegFile.RFMem[6], 44)
+    `assert_equal(uut.RegFile.RFMem[5], 256)
+    `assert_equal(uut.RegFile.RFMem[6], 44)
 
     $finish;
   end


### PR DESCRIPTION
Addressing https://github.com/UTOSS/risc-v/issues/58, I extracted the RF module from the instruction decode and placed it in top.v. Tested it in RISCOF and the tests that are expected to pass are passing. Will also be modifying the testbenches to reflect the new signal locations.

If @MSh-786 completes the task and submits his own PR, feel free to disregard this one and merge his.