### PR TITLE
Cleanup of load/store logic in top.v into new module

### DIFF
--- a/src/Instruction_Decode/MemoryLoader.sv
+++ b/src/Instruction_Decode/MemoryLoader.sv
@@ -1,11 +1,11 @@
 module MemoryLoader (
-    input  logic [31:0] memory_data,
-    input  logic [31:0] memory_address,
+    input  data_t memory_data,
+    input  addr_t memory_address,
     input  logic [2:0]  funct3,
-    output logic [31:0] mem_load_result
+    output data_t mem_load_result
 );
 
-    logic [1:0] byteindex;
+    integer byteindex;
     assign byteindex = memory_address[1:0];
 
     always_comb begin

--- a/src/Instruction_Decode/MemoryLoader.sv
+++ b/src/Instruction_Decode/MemoryLoader.sv
@@ -1,0 +1,57 @@
+module MemoryLoader (
+    input  logic [31:0] memory_data,
+    input  logic [31:0] memory_address,
+    input  logic [2:0]  funct3,
+    output logic [31:0] mem_load_result
+);
+
+    logic [1:0] byteindex;
+    assign byteindex = memory_address[1:0];
+
+    always_comb begin
+        case (funct3)
+            3'b000: begin // lb
+                case (byteindex)
+                    2'd0: mem_load_result = {{24{memory_data[7]}},  memory_data[7:0]};
+                    2'd1: mem_load_result = {{24{memory_data[15]}}, memory_data[15:8]};
+                    2'd2: mem_load_result = {{24{memory_data[23]}}, memory_data[23:16]};
+                    2'd3: mem_load_result = {{24{memory_data[31]}}, memory_data[31:24]};
+                    default: mem_load_result = 32'hX;
+                endcase
+            end
+
+            3'b001: begin // lh
+                case (byteindex)
+                    2'd0: mem_load_result = {{16{memory_data[15]}}, memory_data[15:0]};
+                    2'd1: mem_load_result = {{16{memory_data[23]}}, memory_data[23:8]};
+                    2'd2: mem_load_result = {{16{memory_data[31]}}, memory_data[31:16]};
+                    default: mem_load_result = 32'hX;
+                endcase
+            end
+
+            3'b010: mem_load_result = memory_data; // lw
+
+            3'b100: begin // lbu
+                case (byteindex)
+                    2'd0: mem_load_result = {24'b0, memory_data[7:0]};
+                    2'd1: mem_load_result = {24'b0, memory_data[15:8]};
+                    2'd2: mem_load_result = {24'b0, memory_data[23:16]};
+                    2'd3: mem_load_result = {24'b0, memory_data[31:24]};
+                    default: mem_load_result = 32'hX;
+                endcase
+            end
+
+            3'b101: begin // lhu
+                case (byteindex)
+                    2'd0: mem_load_result = {16'b0, memory_data[15:0]};
+                    2'd1: mem_load_result = {16'b0, memory_data[23:8]};
+                    2'd2: mem_load_result = {16'b0, memory_data[31:16]};
+                    default: mem_load_result = 32'hX;
+                endcase
+            end
+
+            default: mem_load_result = 32'hX;
+        endcase
+    end
+
+endmodule

--- a/src/top.v
+++ b/src/top.v
@@ -107,6 +107,7 @@ module top #( parameter MEM_SIZE = 1024 )
 
   MemoryLoader MemLoad
   ( .memory_data       ( memory_data     )
+  , .memory_address    ( memory_address  )
   , .mem_load_result   ( mem_load_result )
   , .funct3            ( funct3          )
   );

--- a/src/top.v
+++ b/src/top.v
@@ -105,50 +105,11 @@ module top #( parameter MEM_SIZE = 1024 )
     end
   end
 
-  always @(*) begin
-    byteindex = memory_address[1:0];
-    case (funct3)
-    3'b000:    //lb
-      begin
-        case (byteindex)
-        0 : mem_load_result = {{24{memory_data[7]}}, memory_data[7:0]};
-        1 : mem_load_result = {{24{memory_data[15]}}, memory_data[15:8]};
-        2 : mem_load_result = {{24{memory_data[23]}}, memory_data[23:16]};
-        3 : mem_load_result = {{24{memory_data[31]}}, memory_data[31:24]};
-      endcase
-        
-      end 
-    3'b001:   //lh 
-    begin
-        case (byteindex)
-        0 : mem_load_result = {{16{memory_data[15]}}, memory_data[15:0]};
-        1 : mem_load_result = {{16{memory_data[23]}}, memory_data[23:8]};
-        2 : mem_load_result = {{16{memory_data[31]}}, memory_data[31:16]};
-      endcase
-        
-      end
-    3'b010:    mem_load_result = memory_data; //lw
-    3'b100:    
-    begin //lbu
-        case (byteindex)
-        0 : mem_load_result = {{24{1'b0}}, memory_data[7:0]};
-        1 : mem_load_result = {{24{1'b0}}, memory_data[15:8]};
-        2 : mem_load_result = {{24{1'b0}}, memory_data[23:16]};
-        3 : mem_load_result = {{24{1'b0}}, memory_data[31:24]};
-      endcase
-        
-      end 
-    3'b101: //lhu
-    begin
-        case (byteindex)
-        0 : mem_load_result = {{16{1'b0}}, memory_data[15:0]};
-        1 : mem_load_result = {{16{1'b0}}, memory_data[23:8]};
-        2 : mem_load_result = {{16{1'b0}}, memory_data[31:16]};
-      endcase
-
-      end 
-    endcase
-  end
+  MemoryLoader MemLoad
+  ( .memory_data       ( memory_data     )
+  , .mem_load_result   ( mem_load_result )
+  , .funct3            ( funct3          )
+  );
 
   always @(posedge clk) begin
     data <= mem_load_result;


### PR DESCRIPTION
Moved @Invisipac load/store logic into a separate module with the corresponding ports. Tested in RISCOF and all tests that are expected to pass at this stage are passing.