### PR TITLE
 Add SVLint entries for all rules that pass and make the Makefile build the core by default (v2)

### DIFF
--- a/.svlint.toml
+++ b/.svlint.toml
@@ -37,3 +37,51 @@ syntaxrules.style_commaleading = true
 syntaxrules.eventlist_or = true
 
 # Style ruleset end
+
+# from designintents.toml
+syntaxrules.blocking_assignment_in_always_ff = true
+syntaxrules.blocking_assignment_in_always_latch = true
+syntaxrules.non_blocking_assignment_in_always_comb = true
+syntaxrules.case_default = true
+syntaxrules.enum_with_type = true
+syntaxrules.function_with_automatic = true
+syntaxrules.keyword_forbidden_priority = true
+syntaxrules.keyword_forbidden_unique = true
+syntaxrules.keyword_forbidden_unique0 = true
+syntaxrules.operator_case_equality = true
+syntaxrules.procedural_continuous_assignment = true
+syntaxrules.action_block_with_side_effect = true
+# TODO syntaxrules.default_nettype_none = true
+syntaxrules.function_same_as_system_function = true
+# TODO syntaxrules.keyword_forbidden_always = true
+# TODO syntaxrules.keyword_forbidden_wire_reg = true
+syntaxrules.module_nonansi_forbidden = true
+syntaxrules.generate_case_with_label = true
+syntaxrules.generate_for_with_label = true
+syntaxrules.generate_if_with_label = true
+syntaxrules.localparam_type_twostate = true
+syntaxrules.parameter_type_twostate = true
+syntaxrules.localparam_explicit_type = true
+# TODO syntaxrules.parameter_explicit_type = true
+syntaxrules.parameter_default_value = true
+syntaxrules.parameter_in_generate = true
+syntaxrules.parameter_in_package = true
+syntaxrules.genvar_declaration_in_loop = true
+syntaxrules.genvar_declaration_out_loop = false
+syntaxrules.keyword_forbidden_generate = true
+syntaxrules.keyword_required_generate = false
+# TODO syntaxrules.explicit_case_default = true
+# TODO syntaxrules.explicit_if_else = true
+syntaxrules.loop_statement_in_always_comb = true
+syntaxrules.loop_statement_in_always_ff = true
+syntaxrules.loop_statement_in_always_latch = true
+syntaxrules.sequential_block_in_always_comb = true
+syntaxrules.sequential_block_in_always_ff = true
+syntaxrules.sequential_block_in_always_latch = true
+syntaxrules.multiline_for_begin = true
+syntaxrules.multiline_if_begin = true
+syntaxrules.inout_with_tri = true
+# TODO syntaxrules.input_with_var = true
+# TODO syntaxrules.output_with_var = true
+syntaxrules.interface_port_with_modport = true
+

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ RISCOF_DUT_VVP := $(RISCOF_DIR)/dut.vvp
 RISCOF_CONFIG_TEMPLATE := $(RISCOF_DIR)/config.ini.m4
 RISCOF_CONFIG := $(RISCOF_DIR)/config.ini
 
+all: build_top
+	@echo "Build finished! Try 'make run_top' or 'make run_tb' to run the core or testbenches."
+
 print_srcs:
 	@echo $(SRCS)
 


### PR DESCRIPTION
Two changes since they're both pretty small:

* Add SVLint rules for everything in `designintents.toml` that passes and also to make clear what needs doing. Might need discussion on what we *want* to use, e.g. do we want to require every `if` to have an `else`?
* The Makefile (by accident?) always prints the sources by default, which is just enough to trick me into thinking it built successfully. Actually build the core instead and offer help to the user.

Replaces #82, freshly rebased on main.