### PR TITLE
Modifying and using alu_op_t enum

### DIFF
--- a/src/ALU_ALUdecoder/ALUdecoder.v
+++ b/src/ALU_ALUdecoder/ALUdecoder.v
@@ -8,7 +8,7 @@ module ALUdecoder ( input [2:0] funct3
   always @(*)
   begin
   case (alu_op)
-    ALU_OP__MEMORY_ACCESS: alu_control = 4'b0000; //lw, sw (ADD)
+    ALU_OP__ADD: alu_control = 4'b0000; //lw, sw (ADD)
     ALU_OP__BRANCH:
     begin
       case (funct3)

--- a/src/ControlFSM.sv
+++ b/src/ControlFSM.sv
@@ -21,7 +21,7 @@ module ControlFSM
   , output reg Branch
   , output alu_src_a_t ALUSrcA
   , output alu_src_b_t ALUSrcB
-  , output reg [2:0] ALUOp //to ALU Decoder
+  , output alu_op_t ALUOp //to ALU Decoder
   , output result_src_t ResultSrc
   , output reg [4:0] FSMState
   );
@@ -161,7 +161,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__OLD_PC;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= 2'b00;
+        ALUOp <= ALU_OP__ADD;
 
       end
 
@@ -169,7 +169,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__OLD_PC;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= 2'b00;
+        ALUOp <= ALU_OP__ADD;
 
       end
 
@@ -177,7 +177,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__ZERO;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= 2'b00;
+        ALUOp <= ALU_OP__ADD;
 
       end
 
@@ -185,7 +185,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__RD2;
-        ALUOp <= 2'b10;
+        ALUOp <= ALU_OP__REGISTER_OPERATION;
 
       end
 
@@ -193,7 +193,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= 2'b11;
+        ALUOp <= ALU_OP__UNSET;
 
       end
 
@@ -201,7 +201,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__OLD_PC;
         ALUSrcB <= ALU_SRC_B__4;
-        ALUOp <= 2'b00;
+        ALUOp <= ALU_OP__ADD;
         ResultSrc <= RESULT_SRC__ALU_OUT;
         PCUpdate <= 1'b1;
         pc_src    <= PC_SRC__JUMP;  // new added
@@ -211,13 +211,13 @@ module ControlFSM
       JALR_CALC: begin
         ALUSrcA  <= ALU_SRC_A__RD1;      // rs1
         ALUSrcB  <= ALU_SRC_B__IMM_EXT;  // + imm
-        ALUOp    <= 2'b00;
+        ALUOp    <= ALU_OP__ADD;
       end
 
       JALR_STEP2: begin
         ALUSrcA   <= ALU_SRC_A__OLD_PC;  // Calculate link = pc_old + 4, write back in ALUWB
         ALUSrcB   <= ALU_SRC_B__4;
-        ALUOp     <= 2'b00;
+        ALUOp     <= ALU_OP__ADD;
         ResultSrc <= RESULT_SRC__ALU_OUT;
         pc_src    <= PC_SRC__ALU_RESULT; // fetch  (alu_out & ~1) for new PC
         PCUpdate  <= 1'b1;
@@ -228,7 +228,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= 2'b00;
+        ALUOp <= ALU_OP__ADD;
 
       end
 
@@ -236,7 +236,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__RD2;
-        ALUOp <= 2'b01;
+        ALUOp <= ALU_OP__BRANCH;
         ResultSrc <= RESULT_SRC__ALU_OUT;
         Branch <= 1'b1;
         case (funct3)
@@ -262,7 +262,7 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__RD2;
-        ALUOp <= 2'b01;
+        ALUOp <= ALU_OP__BRANCH;
         ResultSrc <= RESULT_SRC__ALU_OUT;
         Branch <= 1'b1;
         if (alu_result == 32'b1) begin

--- a/src/ControlFSM.sv
+++ b/src/ControlFSM.sv
@@ -21,7 +21,6 @@ module ControlFSM
   , output reg Branch
   , output alu_src_a_t ALUSrcA
   , output alu_src_b_t ALUSrcB
-  , output alu_op_t ALUOp //to ALU Decoder
   , output result_src_t ResultSrc
   , output reg [4:0] FSMState
   );
@@ -161,7 +160,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__OLD_PC;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= ALU_OP__ADD;
 
       end
 
@@ -169,7 +167,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__OLD_PC;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= ALU_OP__ADD;
 
       end
 
@@ -177,7 +174,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__ZERO;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= ALU_OP__ADD;
 
       end
 
@@ -185,7 +181,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__RD2;
-        ALUOp <= ALU_OP__REGISTER_OPERATION;
 
       end
 
@@ -193,7 +188,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= ALU_OP__UNSET;
 
       end
 
@@ -201,7 +195,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__OLD_PC;
         ALUSrcB <= ALU_SRC_B__4;
-        ALUOp <= ALU_OP__ADD;
         ResultSrc <= RESULT_SRC__ALU_OUT;
         PCUpdate <= 1'b1;
         pc_src    <= PC_SRC__JUMP;  // new added
@@ -211,13 +204,11 @@ module ControlFSM
       JALR_CALC: begin
         ALUSrcA  <= ALU_SRC_A__RD1;      // rs1
         ALUSrcB  <= ALU_SRC_B__IMM_EXT;  // + imm
-        ALUOp    <= ALU_OP__ADD;
       end
 
       JALR_STEP2: begin
         ALUSrcA   <= ALU_SRC_A__OLD_PC;  // Calculate link = pc_old + 4, write back in ALUWB
         ALUSrcB   <= ALU_SRC_B__4;
-        ALUOp     <= ALU_OP__ADD;
         ResultSrc <= RESULT_SRC__ALU_OUT;
         pc_src    <= PC_SRC__ALU_RESULT; // fetch  (alu_out & ~1) for new PC
         PCUpdate  <= 1'b1;
@@ -228,7 +219,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__IMM_EXT;
-        ALUOp <= ALU_OP__ADD;
 
       end
 
@@ -236,7 +226,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__RD2;
-        ALUOp <= ALU_OP__BRANCH;
         ResultSrc <= RESULT_SRC__ALU_OUT;
         Branch <= 1'b1;
         case (funct3)
@@ -262,7 +251,6 @@ module ControlFSM
 
         ALUSrcA <= ALU_SRC_A__RD1;
         ALUSrcB <= ALU_SRC_B__RD2;
-        ALUOp <= ALU_OP__BRANCH;
         ResultSrc <= RESULT_SRC__ALU_OUT;
         Branch <= 1'b1;
         if (alu_result == 32'b1) begin

--- a/src/Instruction_Decode/Instruction_Decode.v
+++ b/src/Instruction_Decode/Instruction_Decode.v
@@ -15,7 +15,7 @@ module Instruction_Decode
   alu_op_t alu_op;
   //reg [2:0] funct3;
   reg [6:0] funct7;
-  wire [3:0] state;
+  wire [3:0] state; 
 
   assign opcode = instr[6:0];
 
@@ -50,12 +50,12 @@ module Instruction_Decode
   always @(*) begin
     case (opcode)
       RType:      alu_op = ALU_OP__REGISTER_OPERATION;
-      IType_load: alu_op = ALU_OP__MEMORY_ACCESS;
-    IType_jalr: alu_op = ALU_OP__MEMORY_ACCESS; // rs1 + imm
-      SType:      alu_op = ALU_OP__MEMORY_ACCESS;
+      IType_load: alu_op = ALU_OP__ADD;
+    IType_jalr: alu_op = ALU_OP__ADD; // rs1 + imm
+      SType:      alu_op = ALU_OP__ADD;
       BType:      alu_op = ALU_OP__BRANCH;
-    UType_auipc: alu_op = ALU_OP__MEMORY_ACCESS; // used to add 0 to imm ext
-    UType_lui:   alu_op = ALU_OP__MEMORY_ACCESS; // used to add 0 to imm ext
+    UType_auipc: alu_op = ALU_OP__ADD; // used to add 0 to imm ext
+    UType_lui:   alu_op = ALU_OP__ADD; // used to add 0 to imm ext
       default:    alu_op = ALU_OP__UNSET;
 
     endcase

--- a/src/Instruction_Decode/Instruction_Decode.v
+++ b/src/Instruction_Decode/Instruction_Decode.v
@@ -15,7 +15,7 @@ module Instruction_Decode
   alu_op_t alu_op;
   //reg [2:0] funct3;
   reg [6:0] funct7;
-  wire [3:0] state; 
+  wire [3:0] state;
 
   assign opcode = instr[6:0];
 

--- a/src/top.v
+++ b/src/top.v
@@ -41,7 +41,6 @@ module top #( parameter MEM_SIZE = 1024 )
   wire [3:0] __tmp_MemWrite;
   wire __tmp_Branch;
   wire [1:0] __tmp_ALUSrcA, __tmp_ALUSrcB;
-  //wire [2:0] __tmp_ALUOp;
   wire [3:0] __tmp_ALUControl;
   wire [1:0] __tmp_ResultSrc;
   wire [3:0] __tmp_FSMState;

--- a/src/top.v
+++ b/src/top.v
@@ -41,7 +41,7 @@ module top #( parameter MEM_SIZE = 1024 )
   wire [3:0] __tmp_MemWrite;
   wire __tmp_Branch;
   wire [1:0] __tmp_ALUSrcA, __tmp_ALUSrcB;
-  wire [2:0] __tmp_ALUOp;
+  //wire [2:0] __tmp_ALUOp;
   wire [3:0] __tmp_ALUControl;
   wire [1:0] __tmp_ResultSrc;
   wire [3:0] __tmp_FSMState;
@@ -68,7 +68,6 @@ module top #( parameter MEM_SIZE = 1024 )
     , .Branch     ( __tmp_Branch     )
     , .ALUSrcA    ( __tmp_ALUSrcA    )
     , .ALUSrcB    ( __tmp_ALUSrcB    )
-    , .ALUOp      ( __tmp_ALUOp      )
     , .ResultSrc  ( cfsm__result_src )
     , .FSMState   ( __tmp_FSMState   )
     );

--- a/src/types.svh
+++ b/src/types.svh
@@ -13,7 +13,7 @@ typedef logic [6:0] opcode_t;
 
 // based on table 7.2 of digital design and computer architecture book
 typedef enum logic [1:0]
-  { ALU_OP__MEMORY_ACCESS      = 2'b00
+  { ALU_OP__ADD                = 2'b00
   , ALU_OP__BRANCH             = 2'b01
   , ALU_OP__REGISTER_OPERATION = 2'b10
 


### PR DESCRIPTION
- Used `alu_op_t` enum in Control FSM
- renamed the first constant from `memory access` to `add`