### PR TITLE
Optimize memory-only updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ riscof/config.ini
 riscof/dut_sim
 
 envs/de1-soc/poc/poc*.mem
+envs/de1-soc/poc/poc*.mif
 envs/de1-soc/poc/poc.elf
 envs/de1-soc/quartus/db/
 envs/de1-soc/out/**

--- a/envs/de1-soc/Makefile
+++ b/envs/de1-soc/Makefile
@@ -32,6 +32,9 @@ run_tb: $(OUT_DIR)/top_tb_sim
 synthesize:
 	cd quartus && quartus_sh --flow compile utoss-risc-v
 
+refresh_ram:
+	cd quartus && quartus_cdb utoss-risc-v --update_mif && quartus_asm utoss-risc-v
+
 clean:
 	rm -rf $(OUT_DIR) $(BUILD_DIR)
 

--- a/envs/de1-soc/memory_map.sv
+++ b/envs/de1-soc/memory_map.sv
@@ -11,20 +11,13 @@ module memory_map #( parameter SIZE = 1024 )
   , output reg    [9:0] LEDR
   );
 
-  reg [7:0] M0 [0:SIZE - 1];  // byte lane 0
-  reg [7:0] M1 [0:SIZE - 1];  // byte lane 1
-  reg [7:0] M2 [0:SIZE - 1];  // byte lane 2
-  reg [7:0] M3 [0:SIZE - 1];  // byte lane 3
+  reg [7:0] M0 [0:SIZE - 1] /* synthesis ram_init_file = "../../poc/poc0.mif" */;  // byte lane 0
+  reg [7:0] M1 [0:SIZE - 1] /* synthesis ram_init_file = "../../poc/poc1.mif" */;  // byte lane 1
+  reg [7:0] M2 [0:SIZE - 1] /* synthesis ram_init_file = "../../poc/poc2.mif" */;  // byte lane 2
+  reg [7:0] M3 [0:SIZE - 1] /* synthesis ram_init_file = "../../poc/poc3.mif" */;  // byte lane 3
 
   reg [31:0] M [0:SIZE - 1];
   reg [31:0] mem_rdata;
-
-  initial begin
-    $readmemh("poc/poc0.mem", M0);
-    $readmemh("poc/poc1.mem", M1);
-    $readmemh("poc/poc2.mem", M2);
-    $readmemh("poc/poc3.mem", M3);
-  end
 
   localparam bit [31:0] LEDR_ADDRESS = 32'h10000000;
 

--- a/envs/de1-soc/memory_map.sv
+++ b/envs/de1-soc/memory_map.sv
@@ -16,6 +16,17 @@ module memory_map #( parameter SIZE = 1024 )
   reg [7:0] M2 [0:SIZE - 1] /* synthesis ram_init_file = "../../poc/poc2.mif" */;  // byte lane 2
   reg [7:0] M3 [0:SIZE - 1] /* synthesis ram_init_file = "../../poc/poc3.mif" */;  // byte lane 3
 
+// only populate memory from MEM files if we are not synthesizing so that the simulation testbench
+// can run
+`ifndef UTOSS_RISCV_SYNTHESIS
+  initial begin
+    $readmemh("poc/poc0.mem", M0);
+    $readmemh("poc/poc1.mem", M1);
+    $readmemh("poc/poc2.mem", M2);
+    $readmemh("poc/poc3.mem", M3);
+  end
+`endif
+
   reg [31:0] M [0:SIZE - 1];
   reg [31:0] mem_rdata;
 

--- a/envs/de1-soc/poc/Makefile
+++ b/envs/de1-soc/poc/Makefile
@@ -2,7 +2,7 @@ RISCV_PREFIX  := riscv32-unknown-elf
 RISCV_GCC     := $(RISCV_PREFIX)-gcc
 RISCV_OBJCOPY := $(RISCV_PREFIX)-objcopy
 
-all: poc0.mem poc1.mem poc2.mem poc3.mem
+all: poc0.mif poc1.mif poc2.mif poc3.mif
 
 poc.elf: poc.c link.ld
 	$(RISCV_GCC) -march=rv32i -mabi=ilp32 -mno-relax \
@@ -27,7 +27,17 @@ poc0.mem poc1.mem poc2.mem poc3.mem: poc.mem
 	        } \
 	      }' poc.mem
 
+%.mif: %.mem
+	@echo "Converting $< to $@..."
+	@echo "WIDTH=8;" > $@
+	@echo "DEPTH=512;" >> $@
+	@echo "ADDRESS_RADIX=HEX;" >> $@
+	@echo "DATA_RADIX=HEX;" >> $@
+	@echo "CONTENT BEGIN" >> $@
+	@awk 'BEGIN{addr=0} {if($$0 != "") {printf "%X : %s;\n", addr, $$0; addr++}}' $< >> $@
+	@echo "END;" >> $@
+
 clean:
-	rm -f poc.elf poc.mem poc0.mem poc1.mem poc2.mem poc3.mem
+	rm -f poc.elf poc.mem poc0.mif poc1.mif poc2.mif poc3.mif
 
 .PHONY: clean

--- a/envs/de1-soc/quartus/utoss-risc-v.qsf
+++ b/envs/de1-soc/quartus/utoss-risc-v.qsf
@@ -41,7 +41,7 @@ set_global_assignment -name DEVICE 5CSEMA5F31C6
 set_global_assignment -name TOP_LEVEL_ENTITY top
 set_global_assignment -name ORIGINAL_QUARTUS_VERSION 18.1.0
 set_global_assignment -name PROJECT_CREATION_TIME_DATE "23:32:36  OCTOBER 29, 2025"
-set_global_assignment -name LAST_QUARTUS_VERSION "18.1.0 Lite Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "25.1std.0 Lite Edition"
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files
 set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
 set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85


### PR DESCRIPTION
Use MIF files instead of MEM files so that we dont need to re-synthesis every time we want to change the PoC. Will be easier to demo. 