### PR TITLE
Gather FPGA metrics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,3 +155,13 @@ jobs:
         with:
           name: de1-soc-sof
           path: envs/de1-soc/quartus/output_files/utoss-risc-v.sof
+
+      - name: Upload Quartus reports
+        uses: actions/upload-artifact@v4
+        if: steps.synthesize.outcome == 'success'
+        with:
+          name: de1-soc-quartus-reports
+          path: |
+            envs/de1-soc/quartus/output_files/utoss-risc-v.sta.summary
+            envs/de1-soc/quartus/output_files/utoss-risc-v.fit.summary
+          retention-days: 7


### PR DESCRIPTION
Start adding FIT and STA report summaries to CI output. Can later use them for diffing ALM/LUT counts in PRs.