### PR TITLE
Update zba to use proper ISA specification

### DIFF
--- a/src/ext/b/zba.sv
+++ b/src/ext/b/zba.sv
@@ -7,7 +7,6 @@
 
 module zba(input [31:0] reg1
   , input [31:0] reg2
-  , input [1:0] inst // two bit register, distinguish instruction
   , input [2:0] funct3 // extra function inputs
   , input [6:0] funct7
   , output reg[31:0] out
@@ -16,25 +15,30 @@ module zba(input [31:0] reg1
 always @(*)
 begin
 
-    case (inst)
+    case (funct7)
+        7'b0100000: begin
 
-// sh1add behaviour
+                case (funct3)
 
-    2'b00: out = (reg1 << 1) + reg2;
+                // sh1add behaviour
 
-// sh2add behaviour
+                    3'b010: out = (reg1 << 1) + reg2;
 
-    2'b01: out = (reg1 << 2) + reg2;
+                // sh2add behaviour
 
-// sh3add
+                    3'b100: out = (reg1 << 2) + reg2;
 
-    2'b10: out = (reg1 << 3) + reg2;
+                // sh3add
 
-// other
+                    3'b110: out = (reg1 << 3) + reg2;
 
-    default: out = 32'd0;
+                // other
 
+                    default: out = 32'd0;
+            endcase
+        end
     endcase
+
 end
 
 endmodule

--- a/src/ext/b/zba.sv
+++ b/src/ext/b/zba.sv
@@ -9,10 +9,10 @@ module zba(input [31:0] reg1
   , input [31:0] reg2
   , input [2:0] funct3 // extra function inputs
   , input [6:0] funct7
-  , output reg[31:0] out
+  , output logic[31:0] out
   );
 
-always @(*)
+always_comb
 begin
 
     case (funct7)

--- a/test/zba_tb.sv
+++ b/test/zba_tb.sv
@@ -5,20 +5,22 @@ module zba_tb;
 
 reg[31:0] reg1;
 reg[31:0] reg2;
-reg[1:0] inst;
+reg[2:0] funct3;
+reg[6:0] funct7;
 wire[31:0] out;
 
 zba uut(.reg1(reg1)
   , .reg2(reg2)
-  , .inst(inst)
+  , .funct3(funct3)
+  , .funct7(funct7)
   , .out(out)
   );
 
 initial begin
 
-    reg1 = 32'd10; reg2 = 31'd5; inst=2'b00; #20;
-    reg1 = 32'd10; reg2 = 31'd5; inst=2'b01; #20;
-    reg1 = 32'd10; reg2 = 31'd5; inst=2'b10; #20;
+    reg1 = 32'd10; reg2 = 31'd5; funct3=3'b010; funct7=7'b0000000; #20;
+    reg1 = 32'd10; reg2 = 31'd5; funct3=3'b100; funct7=7'b0000000; #20;
+    reg1 = 32'd10; reg2 = 31'd5; funct3=3'b110; funct7=7'b0000000; #20;
 
     $finish;
 


### PR DESCRIPTION
I changed the inputs for the zba to use the funct3 and funct7 fields as outlined in the ISA specification. Removed the instruction input field that was previously used. 