### PR TITLE
Zba format update

### DIFF
--- a/src/ext/b/zba.sv
+++ b/src/ext/b/zba.sv
@@ -14,7 +14,6 @@ module zba(input [31:0] reg1
   );
 
 always_comb
-begin
 
     case (inst)
 
@@ -35,6 +34,5 @@ begin
     default: out = 32'd0;
 
     endcase
-end
 
 endmodule


### PR DESCRIPTION
Updated zba module to use always_comb and logic instead of reg for systemverilog consistency.