### PR TITLE
Changes to the fetch stage

### DIFF
--- a/src/interfaces/ex_to_if_if.svh
+++ b/src/interfaces/ex_to_if_if.svh
@@ -7,7 +7,6 @@
 typedef struct packed {
   pc_src_t pc_src;
   addr_t   pc_old;
-  addr_t   pc_plus_4;
   imm_t    imm_ext;
   addr_t   alu_result_for_pc;
 } ex_to_if_t;

--- a/src/stages/Execute.sv
+++ b/src/stages/Execute.sv
@@ -79,6 +79,7 @@ module Execute
   assign EX_to_MEM.rd               = ID_to_EX.rd;
   assign EX_to_MEM.alu_result       = alu_result;
   assign EX_to_MEM.pc_cur           = ID_to_EX.pc_cur;
+  assign EX_to_MEM.pc_plus_4        = ID_to_EX.pc_plus_4;
   assign EX_to_IF.imm_ext           = ID_to_EX.imm_ext;
   assign EX_to_IF.pc_src            = (JumpE | (zero_flag & BranchE)) ? PC_SRC__ALU_RESULT: PC_SRC__INCREMENT;
   assign EX_to_IF.alu_result_for_pc = alu_result;

--- a/src/stages/Execute.sv
+++ b/src/stages/Execute.sv
@@ -83,6 +83,4 @@ module Execute
   assign EX_to_IF.pc_src            = (JumpE | (zero_flag & BranchE)) ? PC_SRC__ALU_RESULT: PC_SRC__INCREMENT;
   assign EX_to_IF.alu_result_for_pc = alu_result;
   assign EX_to_IF.pc_old            = ID_to_EX.pc_cur;
-  assign EX_to_IF.pc_plus_4         = ID_to_EX.pc_plus_4;
-
 endmodule

--- a/src/stages/Execute.sv
+++ b/src/stages/Execute.sv
@@ -19,7 +19,6 @@ module Execute
 
   , output wire zero_flag
   , output data_t alu_result
-  , output addr_t pc_target
   , output ex_to_if_t EX_to_IF
   , output ex_to_mem_t EX_to_MEM
   );
@@ -58,8 +57,6 @@ module Execute
       EXECUTE_ALU_SRC_B__IMM_EXT: alu_input_b = ID_to_EX.imm_ext;
       default:                    alu_input_b = 'x;
     endcase
-
-  assign pc_target = ID_to_EX.imm_ext + ID_to_EX.pc_cur;
 
   ALU alu
     ( .a              ( alu_input_a         )

--- a/src/stages/fetch_stage.sv
+++ b/src/stages/fetch_stage.sv
@@ -21,16 +21,13 @@ module fetch_stage
   addr_t pc_previous;
   addr_t pc_next;
 
-  always @ (posedge clk)
-    if (reset) begin
-      pc_current <= 0;
-    end else if (!StallF) begin
-      case (EX_to_IF.pc_src)
-        PC_SRC__INCREMENT:  pc_next <= pc_previous + 32'h4;
-        PC_SRC__JUMP:       pc_next <= EX_to_IF.pc_old + EX_to_IF.imm_ext;
-        PC_SRC__ALU_RESULT: pc_next <= {EX_to_IF.alu_result_for_pc[31:1], 1'b0};
-      endcase
-    end
+  always_comb
+    case (EX_to_IF.pc_src)
+      PC_SRC__INCREMENT:  pc_next = pc_previous + 32'h4;
+      PC_SRC__JUMP:       pc_next = EX_to_IF.pc_old + EX_to_IF.imm_ext;
+      PC_SRC__ALU_RESULT: pc_next = {EX_to_IF.alu_result_for_pc[31:1], 1'b0};
+      default:            pc_next = 32'hx;
+    endcase
 
   always @ (posedge clk)
     if (!StallF) pc_previous <= reset ? 0 : pc_next;

--- a/src/stages/fetch_stage.sv
+++ b/src/stages/fetch_stage.sv
@@ -14,29 +14,29 @@ module fetch_stage
   , output addr_t imem__address
   , input data_t imem__data
 );
-  addr_t pc_cur;
-  addr_t pc_plus_4;
+  // Decode needs to end up getting the same address as was given to imemory.
+  // At the start of the clock cycle, we need to indicate to decode the address
+  // and content of the previous instruction, while telling memory the address
+  // of the next instruction.
+  addr_t pc_previous;
+  addr_t pc_next;
 
   always @ (posedge clk)
     if (reset) begin
-      pc_cur <= 0;
-      pc_plus_4 <= 0;
-    end
-    else begin
-      pc_cur <= imem__address;
-      pc_plus_4 <= pc_cur + 32'h4;
-    end
-
-  always @ (posedge clk)
-    if (!StallF) begin
+      pc_current <= 0;
+    end else if (!StallF) begin
       case (EX_to_IF.pc_src)
-        PC_SRC__INCREMENT:  imem__address <= pc_plus_4;
-        PC_SRC__JUMP:       imem__address <= EX_to_IF.pc_old + EX_to_IF.imm_ext;
-        PC_SRC__ALU_RESULT: imem__address <= {EX_to_IF.alu_result_for_pc[31:1], 1'b0};
+        PC_SRC__INCREMENT:  pc_next <= pc_previous + 32'h4;
+        PC_SRC__JUMP:       pc_next <= EX_to_IF.pc_old + EX_to_IF.imm_ext;
+        PC_SRC__ALU_RESULT: pc_next <= {EX_to_IF.alu_result_for_pc[31:1], 1'b0};
       endcase
     end
 
+  always @ (posedge clk)
+    if (!StallF) pc_previous <= reset ? 0 : pc_next;
+
+  assign imem__address = pc_next;
   assign IF_to_ID.instruction = imem__data;
-  assign IF_to_ID.pc_cur = pc_cur;
-  assign IF_to_ID.pc_plus_4 = pc_plus_4;
+  assign IF_to_ID.pc_cur = pc_previous;
+  assign IF_to_ID.pc_plus_4 = pc_previous + 32'h4;
 endmodule

--- a/src/utoss_riscv_pipelined.sv
+++ b/src/utoss_riscv_pipelined.sv
@@ -37,7 +37,6 @@ module utoss_riscv_pipelined
   ex_to_mem_t ex_to_mem_out;
   ex_to_mem_t ex_to_mem_reg;
 
-  addr_t pc_target;
   logic  zero_flag;
   data_t alu_result;
 
@@ -106,7 +105,6 @@ module utoss_riscv_pipelined
 
     , .zero_flag  ( zero_flag     )
     , .alu_result ( alu_result    )
-    , .pc_target  ( pc_target     ) // TODO: Bring this into the Fetch stage
     , .EX_to_MEM  ( ex_to_mem_out )
     , .EX_to_IF   ( ex_to_if_out  )
     );


### PR DESCRIPTION
Originally meant to target Boris' comment:

> hey thatlittlegit i think we might want to set pc_next as part of this mux (combinationally instead of on the clock), and then have imem_address track pc_cur;

I think I also just went around and messed with the nomenclature in the fetch stage, which I think makes it more clear how it works, but I also tried to make pc_next combinational. I also removed some unused entries in the interfaces that I noticed.

(Brief aside: I'm not a fan of pc_plus_4 being plumbed through all the stages, but not sure if it's worth changing? Plausibly just pc_cur gets plumbed and `pc_cur+4` is computed in write_back.)