### PR TITLE
Refractor Zbs to use ALU enum types and Update testbench accordingly.

### DIFF
--- a/src/ext/b/zbs.sv
+++ b/src/ext/b/zbs.sv
@@ -13,7 +13,7 @@
 module zbs (
     input  data_t reg1 // rs1 operand
   , input  data_t reg2 // rs2 or immediate (bit index source)
-    , input  alu_control_t inst // operation selector
+  , input  alu_control_t inst // operation selector
   , output data_t out //result
 );
 

--- a/src/ext/b/zbs.sv
+++ b/src/ext/b/zbs.sv
@@ -20,30 +20,28 @@ module zbs (
     logic [4:0] index;
     data_t mask;
 
-    always_comb
+    always_comb begin
         index = reg2[4:0];
-
-    always_comb
         mask = data_t'(32'h1) << index;
 
-    always_comb
-        case (inst)
+        case ( inst )
 
-            // 00 : bclr / bclri  → clear selected bit
+            // bclr / bclri  → clear selected bit
             ALU_CONTROL_BCLR: out = reg1 & ~mask;
 
-            // 01 : bset / bseti  → set selected bit
+            // bset / bseti  → set selected bit
             ALU_CONTROL_BSET: out = reg1 | mask;
 
-            // 10 : binv / binvi  → invert selected bit
+            // binv / binvi  → invert selected bit
             ALU_CONTROL_BINV: out = reg1 ^ mask;
 
-            // 11 : bext / bexti  → extract selected bit (to bit[0])
+            // bext / bexti  → extract selected bit (to bit[0])
             ALU_CONTROL_BEXT: out = (reg1 >> index) & data_t'(32'h1);
 
-            // others → safe default
+            // safe default
             default: out = '0;
 
         endcase
+    end
 
 endmodule

--- a/src/ext/b/zbs.sv
+++ b/src/ext/b/zbs.sv
@@ -13,7 +13,7 @@
 module zbs (
     input  data_t reg1 // rs1 operand
   , input  data_t reg2 // rs2 or immediate (bit index source)
-  , input  logic [1:0] inst // operation selector
+    , input  alu_control_t inst // operation selector
   , output data_t out //result
 );
 
@@ -30,16 +30,16 @@ module zbs (
         case (inst)
 
             // 00 : bclr / bclri  → clear selected bit
-            2'b00: out = reg1 & ~mask;
+            ALU_CONTROL_BCLR: out = reg1 & ~mask;
 
             // 01 : bset / bseti  → set selected bit
-            2'b01: out = reg1 | mask;
+            ALU_CONTROL_BSET: out = reg1 | mask;
 
             // 10 : binv / binvi  → invert selected bit
-            2'b10: out = reg1 ^ mask;
+            ALU_CONTROL_BINV: out = reg1 ^ mask;
 
             // 11 : bext / bexti  → extract selected bit (to bit[0])
-            2'b11: out = (reg1 >> index) & data_t'(32'h1);
+            ALU_CONTROL_BEXT: out = (reg1 >> index) & data_t'(32'h1);
 
             // others → safe default
             default: out = '0;

--- a/src/types.svh
+++ b/src/types.svh
@@ -34,6 +34,10 @@ typedef enum logic [3:0]
     , ALU_CONTROL_SRA  = 4'b0111
     , ALU_CONTROL_OR   = 4'b1000
     , ALU_CONTROL_AND  = 4'b1001
+    , ALU_CONTROL_BCLR = 4'b1010
+    , ALU_CONTROL_BSET = 4'b1011
+    , ALU_CONTROL_BINV = 4'b1100
+    , ALU_CONTROL_BEXT = 4'b1101
 } alu_control_t;
 
 // represents the possible input sources for the first operand of the ALU as selected by the Control

--- a/test/zbs_tb.sv
+++ b/test/zbs_tb.sv
@@ -5,7 +5,7 @@ module zbs_tb;
 
 logic [31:0] reg1;
 logic [31:0] reg2;
-logic [2:0]  inst;
+alu_control_t inst;
 logic [31:0] out;
 
 logic [31:0] expected;
@@ -22,7 +22,7 @@ initial begin
     // -------- bclr test --------
     reg1 = 32'b1010;
     reg2 = 32'd1;   // clear bit 1
-    inst = 3'b000;
+    inst = ALU_CONTROL_BCLR;
     #10;
 
     expected = reg1 & ~(32'h1 << reg2[4:0]);
@@ -34,7 +34,7 @@ initial begin
     // -------- bset test --------
     reg1 = 32'b1110;
     reg2 = 32'd0;   // set bit 0
-    inst = 3'b001;
+    inst = ALU_CONTROL_BSET;
     #10;
 
     expected = reg1 | (32'h1 << reg2[4:0]);
@@ -46,7 +46,7 @@ initial begin
     // -------- binv test --------
     reg1 = 32'b1010;
     reg2 = 32'd1;
-    inst = 3'b010;
+    inst = ALU_CONTROL_BINV;
     #10;
 
     expected = reg1 ^ (32'h1 << reg2[4:0]);
@@ -58,7 +58,7 @@ initial begin
     // -------- bext test --------
     reg1 = 32'b1010;
     reg2 = 32'd3;
-    inst = 3'b011;
+    inst = ALU_CONTROL_BEXT;
     #10;
 
     expected = {31'b0, reg1[reg2[4:0]]};
@@ -71,7 +71,7 @@ initial begin
     // Bit 0 boundary
     reg1 = 32'hFFFFFFFF;
     reg2 = 32'd0;
-    inst = 3'b000; // bclr
+    inst = ALU_CONTROL_BCLR; // bclr
     #10;
 
     expected = reg1 & ~(32'h1 << reg2[4:0]);
@@ -83,7 +83,7 @@ initial begin
     // Bit 31 boundary
     reg1 = 32'hFFFFFFFF;
     reg2 = 32'd31;
-    inst = 3'b000; // bclr
+    inst = ALU_CONTROL_BCLR; // bclr
     #10;
 
     expected = reg1 & ~(32'h1 << reg2[4:0]);
@@ -98,19 +98,19 @@ initial begin
 
         reg1 = $urandom;
         reg2 = $urandom % 32;
-        inst = $urandom % 4;
+        inst = alu_control_t'((4'b1010) + ($urandom % 4));
 
         #1;
 
         case (inst)
 
-            3'b000: expected = reg1 & ~(32'h1 << reg2[4:0]);
+            ALU_CONTROL_BCLR: expected = reg1 & ~(32'h1 << reg2[4:0]);
 
-            3'b001: expected = reg1 | (32'h1 << reg2[4:0]);
+            ALU_CONTROL_BSET: expected = reg1 | (32'h1 << reg2[4:0]);
 
-            3'b010: expected = reg1 ^ (32'h1 << reg2[4:0]);
+            ALU_CONTROL_BINV: expected = reg1 ^ (32'h1 << reg2[4:0]);
 
-            3'b011: expected = {31'b0, reg1[reg2[4:0]]};
+            ALU_CONTROL_BEXT: expected = {31'b0, reg1[reg2[4:0]]};
 
             default: expected = 32'd0;
 

--- a/test/zbs_tb.sv
+++ b/test/zbs_tb.sv
@@ -39,8 +39,8 @@ initial begin
 
     expected = reg1 | (32'h1 << reg2[4:0]);
 
-     assert (out == expected) else
-      $fatal("bset failed: expected %b got %b", expected, out);
+    assert (out == expected) else
+     $fatal("bset failed: expected %b got %b", expected, out);
 
 
     // -------- binv test --------

--- a/test/zbs_tb.sv
+++ b/test/zbs_tb.sv
@@ -130,4 +130,5 @@ end
 
 `SETUP_VCD_DUMP(zbs_tb)
 
+
 endmodule

--- a/test/zbs_tb.sv
+++ b/test/zbs_tb.sv
@@ -27,8 +27,8 @@ initial begin
 
     expected = reg1 & ~(32'h1 << reg2[4:0]);
 
-    assert (out == expected)
-        else $fatal("bclr failed: expected %b got %b", expected, out);
+    assert (out == expected) else
+     $fatal("bclr failed: expected %b got %b", expected, out);
 
 
     // -------- bset test --------
@@ -39,8 +39,8 @@ initial begin
 
     expected = reg1 | (32'h1 << reg2[4:0]);
 
-    assert (out == expected)
-        else $fatal("bset failed: expected %b got %b", expected, out);
+     assert (out == expected) else
+      $fatal("bset failed: expected %b got %b", expected, out);
 
 
     // -------- binv test --------
@@ -51,8 +51,8 @@ initial begin
 
     expected = reg1 ^ (32'h1 << reg2[4:0]);
 
-    assert (out == expected)
-        else $fatal("binv failed: expected %b got %b", expected, out);
+    assert (out == expected) else
+     $fatal("binv failed: expected %b got %b", expected, out);
 
 
     // -------- bext test --------
@@ -63,8 +63,8 @@ initial begin
 
     expected = {31'b0, reg1[reg2[4:0]]};
 
-    assert (out == expected)
-        else $fatal("bext failed: expected %b got %b", expected, out);
+    assert (out == expected) else
+     $fatal("bext failed: expected %b got %b", expected, out);
 
     // -------- Edge Cases ---------
 
@@ -76,8 +76,8 @@ initial begin
 
     expected = reg1 & ~(32'h1 << reg2[4:0]);
 
-    assert (out == expected)
-        else $fatal("corner case bit0 failed");
+    assert (out == expected) else
+     $fatal("corner case bit0 failed");
 
 
     // Bit 31 boundary
@@ -88,29 +88,37 @@ initial begin
 
     expected = reg1 & ~(32'h1 << reg2[4:0]);
 
-    assert (out == expected)
-        else $fatal("corner case bit31 failed");
+    assert (out == expected) else
+     $fatal("corner case bit31 failed");
 
 
     // ----------- Randomized Testing (Experimental) -----------
 
     repeat (1000) begin
 
-        reg1 = $urandom;
-        reg2 = $urandom % 32;
-        inst = alu_control_t'((4'b1010) + ($urandom % 4));
+                reg1 = $urandom;
+                reg2 = $urandom % 32;
 
-        #1;
+                // pick a Zbs operation without arithmetic on enums to avoid width expansion
+                case ($urandom % 4)
+                    0: inst = ALU_CONTROL_BCLR;
+                    1: inst = ALU_CONTROL_BSET;
+                    2: inst = ALU_CONTROL_BINV;
+                    3: inst = ALU_CONTROL_BEXT;
+                    default: inst = ALU_CONTROL_BCLR;
+                endcase
 
-        case (inst)
+                #1;
 
-            ALU_CONTROL_BCLR: expected = reg1 & ~(32'h1 << reg2[4:0]);
+                case ( inst )
 
-            ALU_CONTROL_BSET: expected = reg1 | (32'h1 << reg2[4:0]);
+                        ALU_CONTROL_BCLR: expected = reg1 & ~(32'h1 << reg2[4:0]);
 
-            ALU_CONTROL_BINV: expected = reg1 ^ (32'h1 << reg2[4:0]);
+                        ALU_CONTROL_BSET: expected = reg1 | (32'h1 << reg2[4:0]);
 
-            ALU_CONTROL_BEXT: expected = {31'b0, reg1[reg2[4:0]]};
+                        ALU_CONTROL_BINV: expected = reg1 ^ (32'h1 << reg2[4:0]);
+
+                        ALU_CONTROL_BEXT: expected = {31'b0, reg1[reg2[4:0]]};
 
             default: expected = 32'd0;
 


### PR DESCRIPTION
Refractored Zbs raw bit selector to the existing alu_control_t enum. Four new Zbs operations were added to types.svh and the Zbs testbench is updated accordingly. 