### PR TITLE
Add decoder for C extension

### DIFF
--- a/src/ext/c/Compressed_Decode.sv
+++ b/src/ext/c/Compressed_Decode.sv
@@ -1,0 +1,111 @@
+`include "src/headers/params.svh"
+`include "src/headers/types.svh"
+`include "src/timescale.svh"
+
+module Compressed_Decode
+  ( input wire [15:0] instr_c // Compressed input instruction
+  , output reg [31:0] instr_out // Expanded instruction
+  );
+
+  wire [1:0] quadrant = instr_c[1:0];
+  wire [2:0] funct3   = instr_c[15:13];
+
+  // Common locations of registers in instruction format
+  wire [4:0] rd_prime  = {2'b01, instr_c[4:2]};
+  wire [4:0] rs1_prime = {2'b01, instr_c[9:7]};
+  wire [4:0] rs2_prime = {2'b01, instr_c[4:2]};
+  wire [4:0] rd_full  = instr_c[11:7];
+  wire [4:0] rs1_full = instr_c[11:7];
+  wire [4:0] rs2_full = instr_c[6:2];
+  wire [4:0] shamt = instr_c[6:2];
+
+  // Pre-compute immediates for each instruction format
+  wire [11:0] ciw_imm     = {2'b00, instr_c[10:7], instr_c[12:11], instr_c[5], instr_c[6], 2'b00};
+  wire [11:0] cl_cs_imm   = {5'b00000, instr_c[5], instr_c[12:10], instr_c[6], 2'b00};
+  wire [11:0] ci_imm      = {{6{instr_c[12]}}, instr_c[12], instr_c[6:2]};
+  wire [11:0] ci_sp_imm   = {{3{instr_c[12]}}, instr_c[4:3], instr_c[5], instr_c[2], instr_c[6], 4'b0000};
+  wire [19:0] ci_lui_imm  = {{14{instr_c[12]}}, instr_c[12], instr_c[6:2]};
+  wire [20:0] cj_imm      = {{9{instr_c[12]}}, instr_c[12], instr_c[8], instr_c[10:9], instr_c[6], instr_c[7], instr_c[2], instr_c[11], instr_c[5:3], 1'b0};
+  wire [12:0] cb_imm      = {{4{instr_c[12]}}, instr_c[12], instr_c[6:5], instr_c[2], instr_c[11:10], instr_c[4:3], 1'b0};
+  wire [11:0] ci_lwsp_imm = {4'b0000, instr_c[3:2], instr_c[12], instr_c[6:4], 2'b00};
+  wire [11:0] css_imm     = {4'b0000, instr_c[8:7], instr_c[12:9], 2'b00};
+
+  localparam bit [31:0] NOP = 32'h00000013;
+
+  // TODO: add checks for illegal/reserved instructions (currently not handled)
+  // Note: C.FLW, C.FSW, C.FLD, C.FSD, C.FLWSP, C.FLDSP, C.FSWSP, C.FSDSP should be added alongside future F/D extension support.
+  always @(*) begin
+    case (quadrant) // Opcode (see https://docs.riscv.org/reference/isa/unpriv/c-st-ext.html)
+      2'b11: instr_out = instr_c; // Not a compressed instruction, just pass through
+
+      2'b00: begin // Quadrant 0
+        case (funct3)
+          3'b000: instr_out = {ciw_imm, 5'd2, 3'b000, rd_prime, IType_logic}; // C.ADDI4SPN
+          3'b010: instr_out = {cl_cs_imm, rs1_prime, 3'b010, rd_prime, IType_load}; // C.LW
+          3'b110: instr_out = {cl_cs_imm[11:5], rs2_prime, rs1_prime, 3'b010, cl_cs_imm[4:0], SType}; // C.SW
+          default: instr_out = NOP;
+        endcase
+      end
+
+      2'b01: begin // Quadrant 1
+        case (funct3)
+          3'b000: instr_out = {ci_imm, rd_full, 3'b000, rd_full, IType_logic}; // C.ADDI
+          // TODO C.JAL does not expand exactly to a base RVI instruction since the link address should be pc+2 instead of pc+4
+          // Need to add support for offset of 2 bytes (add an is_compressed output?)
+          3'b001: instr_out = {cj_imm[20], cj_imm[10:1], cj_imm[11], cj_imm[19:12], 5'd1, JType}; // C.JAL
+          3'b010: instr_out = {ci_imm, 5'd0, 3'b000, rd_full, IType_logic}; // C.LI
+          3'b011: begin
+            case (instr_c[11:7])
+              5'd2: instr_out = {ci_sp_imm, 5'd2, 3'b000, 5'd2, IType_logic}; // C.ADDI16SP
+              default: instr_out = {ci_lui_imm, rd_full, UType_lui}; // C.LUI
+            endcase
+          end
+          3'b100: begin
+            case (instr_c[11:10])
+              2'b00: instr_out = {7'h00, instr_c[6:2], rs1_prime, 3'b101, rs1_prime, IType_logic}; // C.SRLI
+              2'b01: instr_out = {7'h20, instr_c[6:2], rs1_prime, 3'b101, rs1_prime, IType_logic}; // C.SRAI
+              2'b10: instr_out = {ci_imm, rs1_prime, 3'b111, rs1_prime, IType_logic}; // C.ANDI
+              2'b11: begin
+                case (instr_c[6:5])
+                  2'b00: instr_out = {7'h20, rs2_prime, rs1_prime, 3'b000, rs1_prime, RType}; // C.SUB
+                  2'b01: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b100, rs1_prime, RType}; // C.XOR
+                  2'b10: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b110, rs1_prime, RType}; // C.OR
+                  2'b11: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b111, rs1_prime, RType}; // C.AND
+                  default: instr_out = NOP;
+                endcase
+              end
+              default: instr_out = NOP;
+            endcase
+          end
+          3'b101: instr_out = {cj_imm[20], cj_imm[10:1], cj_imm[11], cj_imm[19:12], 5'd0, JType}; // C.J
+          3'b110: instr_out = {cb_imm[12], cb_imm[10:5], 5'd0, rs1_prime, 3'b000, cb_imm[4:1], cb_imm[11], BType}; // C.BEQZ
+          3'b111: instr_out = {cb_imm[12], cb_imm[10:5], 5'd0, rs1_prime, 3'b001, cb_imm[4:1], cb_imm[11], BType}; // C.BNEZ
+          default: instr_out = NOP;
+        endcase
+      end
+
+      2'b10: begin // Quadrant 2
+        case (funct3)
+          3'b000: instr_out = {7'h00, shamt, rd_full, 3'b001, rd_full, IType_logic}; // C.SLLI
+          3'b010: instr_out = {ci_lwsp_imm, 5'd2, 3'b010, rd_full, IType_load}; // C.LWSP
+          3'b100: begin
+            case ({instr_c[12], instr_c[11:7] != 5'd0, instr_c[6:2] != 5'd0})
+              3'b010: instr_out = {12'd0, rs1_full, 3'h0, 5'd0, IType_jalr}; // C.JR
+              3'b011: instr_out = {7'h00, rs2_full, 5'd0, 3'h0, rd_full, RType}; // C.MV
+              3'b100: instr_out = {12'h001, 5'd0, 3'h0, 5'd0, SYSTEM}; // C.EBREAK
+              // TODO see note on C.JAL
+              3'b110: instr_out = {12'd0, rs1_full, 3'h0, 5'd1, IType_jalr}; // C.JALR
+              3'b111: instr_out = {7'h00, rs2_full, rd_full, 3'h0, rd_full, RType}; // C.ADD
+              default: instr_out = NOP;
+            endcase
+          end
+          3'b110: instr_out = {css_imm[11:5], rs2_full, 5'd2, 3'b010, css_imm[4:0], SType}; // C.SWSP
+          default: instr_out = NOP;
+        endcase
+      end
+
+      default: instr_out = NOP;
+    endcase
+  end
+
+endmodule

--- a/src/ext/c/Compressed_Decode.sv
+++ b/src/ext/c/Compressed_Decode.sv
@@ -5,6 +5,7 @@
 module Compressed_Decode
   ( input wire [15:0] instr_c // Compressed input instruction
   , output reg [31:0] instr_out // Expanded instruction
+  , output reg is_illegal // Illegal or not implemented
   );
 
   wire [1:0] quadrant = instr_c[1:0];
@@ -32,18 +33,23 @@ module Compressed_Decode
 
   localparam bit [31:0] NOP = 32'h00000013;
 
-  // TODO: add checks for illegal/reserved instructions (currently not handled)
   // Note: C.FLW, C.FSW, C.FLD, C.FSD, C.FLWSP, C.FLDSP, C.FSWSP, C.FSDSP should be added alongside future F/D extension support.
   always @(*) begin
-    case (quadrant) // Opcode (see https://docs.riscv.org/reference/isa/unpriv/c-st-ext.html)
-      2'b11: instr_out = instr_c; // Not a compressed instruction, just pass through
+    instr_out = NOP;
+    is_illegal = 1'b0;
+
+    case (quadrant) // Opcode
+      2'b11: instr_out = {16'b0, instr_c}; // Not a compressed instruction, just pass through (should not actually happen i think?)
 
       2'b00: begin // Quadrant 0
         case (funct3)
-          3'b000: instr_out = {ciw_imm, 5'd2, 3'b000, rd_prime, IType_logic}; // C.ADDI4SPN
+          3'b000: begin
+            instr_out = {ciw_imm, 5'd2, 3'b000, rd_prime, IType_logic}; // C.ADDI4SPN
+            if (ciw_imm == 12'b0) is_illegal = 1'b1;
+          end
           3'b010: instr_out = {cl_cs_imm, rs1_prime, 3'b010, rd_prime, IType_load}; // C.LW
           3'b110: instr_out = {cl_cs_imm[11:5], rs2_prime, rs1_prime, 3'b010, cl_cs_imm[4:0], SType}; // C.SW
-          default: instr_out = NOP;
+          default: is_illegal = 1'b1;
         endcase
       end
 
@@ -51,27 +57,39 @@ module Compressed_Decode
         case (funct3)
           3'b000: instr_out = {ci_imm, rd_full, 3'b000, rd_full, IType_logic}; // C.ADDI
           // TODO C.JAL does not expand exactly to a base RVI instruction since the link address should be pc+2 instead of pc+4
-          // Need to add support for offset of 2 bytes (add an is_compressed output?)
+          // Need to add support for offset of 2 bytes and e.g. preserve an is_compressed wire
           3'b001: instr_out = {cj_imm[20], cj_imm[10:1], cj_imm[11], cj_imm[19:12], 5'd1, JType}; // C.JAL
           3'b010: instr_out = {ci_imm, 5'd0, 3'b000, rd_full, IType_logic}; // C.LI
           3'b011: begin
             case (instr_c[11:7])
-              5'd2: instr_out = {ci_sp_imm, 5'd2, 3'b000, 5'd2, IType_logic}; // C.ADDI16SP
-              default: instr_out = {ci_lui_imm, rd_full, UType_lui}; // C.LUI
+              5'd2: begin
+                instr_out = {ci_sp_imm, 5'd2, 3'b000, 5'd2, IType_logic}; // C.ADDI16SP
+                if (ci_sp_imm == 12'b0) is_illegal = 1'b1;
+              end
+              default: begin
+                instr_out = {ci_lui_imm, rd_full, UType_lui}; // C.LUI
+                if (ci_lui_imm == 20'b0 ) is_illegal = 1'b1;
+              end
             endcase
           end
           3'b100: begin
             case (instr_c[11:10])
-              2'b00: instr_out = {7'h00, instr_c[6:2], rs1_prime, 3'b101, rs1_prime, IType_logic}; // C.SRLI
-              2'b01: instr_out = {7'h20, instr_c[6:2], rs1_prime, 3'b101, rs1_prime, IType_logic}; // C.SRAI
+              2'b00: begin
+                instr_out = {7'h00, instr_c[6:2], rs1_prime, 3'b101, rs1_prime, IType_logic}; // C.SRLI
+                if (instr_c[12]) is_illegal = 1'b1;
+              end
+              2'b01: begin
+                instr_out = {7'h20, instr_c[6:2], rs1_prime, 3'b101, rs1_prime, IType_logic}; // C.SRAI
+                if (instr_c[12]) is_illegal = 1'b1;
+              end
               2'b10: instr_out = {ci_imm, rs1_prime, 3'b111, rs1_prime, IType_logic}; // C.ANDI
               2'b11: begin
+                if (instr_c[12]) is_illegal = 1'b1;
                 case (instr_c[6:5])
                   2'b00: instr_out = {7'h20, rs2_prime, rs1_prime, 3'b000, rs1_prime, RType}; // C.SUB
                   2'b01: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b100, rs1_prime, RType}; // C.XOR
                   2'b10: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b110, rs1_prime, RType}; // C.OR
                   2'b11: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b111, rs1_prime, RType}; // C.AND
-                  default: instr_out = NOP;
                 endcase
               end
               default: instr_out = NOP;
@@ -80,31 +98,33 @@ module Compressed_Decode
           3'b101: instr_out = {cj_imm[20], cj_imm[10:1], cj_imm[11], cj_imm[19:12], 5'd0, JType}; // C.J
           3'b110: instr_out = {cb_imm[12], cb_imm[10:5], 5'd0, rs1_prime, 3'b000, cb_imm[4:1], cb_imm[11], BType}; // C.BEQZ
           3'b111: instr_out = {cb_imm[12], cb_imm[10:5], 5'd0, rs1_prime, 3'b001, cb_imm[4:1], cb_imm[11], BType}; // C.BNEZ
-          default: instr_out = NOP;
         endcase
       end
 
       2'b10: begin // Quadrant 2
         case (funct3)
-          3'b000: instr_out = {7'h00, shamt, rd_full, 3'b001, rd_full, IType_logic}; // C.SLLI
-          3'b010: instr_out = {ci_lwsp_imm, 5'd2, 3'b010, rd_full, IType_load}; // C.LWSP
+          3'b000: begin
+            instr_out = {7'h00, shamt, rd_full, 3'b001, rd_full, IType_logic}; // C.SLLI
+            if (instr_c[12]) is_illegal = 1'b1;
+          end
+          3'b010: begin
+            instr_out = {ci_lwsp_imm, 5'd2, 3'b010, rd_full, IType_load}; // C.LWSP
+            if (rd_full == 5'd0) is_illegal = 1'b1;
+          end
           3'b100: begin
             case ({instr_c[12], instr_c[11:7] != 5'd0, instr_c[6:2] != 5'd0})
-              3'b010: instr_out = {12'd0, rs1_full, 3'h0, 5'd0, IType_jalr}; // C.JR
-              3'b011: instr_out = {7'h00, rs2_full, 5'd0, 3'h0, rd_full, RType}; // C.MV
-              3'b100: instr_out = {12'h001, 5'd0, 3'h0, 5'd0, SYSTEM}; // C.EBREAK
-              // TODO see note on C.JAL
-              3'b110: instr_out = {12'd0, rs1_full, 3'h0, 5'd1, IType_jalr}; // C.JALR
-              3'b111: instr_out = {7'h00, rs2_full, rd_full, 3'h0, rd_full, RType}; // C.ADD
-              default: instr_out = NOP;
+              3'b010:         instr_out = {12'd0, rs1_full, 3'h0, 5'd0, IType_jalr}; // C.JR
+              3'b011, 3'b001: instr_out = {7'h00, rs2_full, 5'd0, 3'h0, rd_full, RType}; // C.MV
+              3'b100:         instr_out = {12'h001, 5'd0, 3'h0, 5'd0, SYSTEM}; // C.EBREAK
+              3'b110:         instr_out = {12'd0, rs1_full, 3'h0, 5'd1, IType_jalr}; // C.JALR (TODO see note on C.JAL)
+              3'b111, 3'b101: instr_out = {7'h00, rs2_full, rd_full, 3'h0, rd_full, RType}; // C.ADD
+              default: is_illegal = 1'b1;
             endcase
           end
           3'b110: instr_out = {css_imm[11:5], rs2_full, 5'd2, 3'b010, css_imm[4:0], SType}; // C.SWSP
-          default: instr_out = NOP;
+          default: is_illegal = 1'b1;
         endcase
       end
-
-      default: instr_out = NOP;
     endcase
   end
 

--- a/src/ext/c/Compressed_Decode.sv
+++ b/src/ext/c/Compressed_Decode.sv
@@ -33,6 +33,75 @@ module Compressed_Decode
 
   localparam bit [31:0] NOP = 32'h00000013;
 
+  // Helpers to expand compressed instructions based on corresponding 32-bit instruction formats
+  function automatic logic [31:0] build_r_instr
+    ( input logic [6:0] funct7
+    , input logic [4:0] rs2
+    , input logic [4:0] rs1
+    , input logic [2:0] funct3
+    , input logic [4:0] rd
+    , input logic [6:0] opcode
+    );
+    return {funct7, rs2, rs1, funct3, rd, opcode};
+  endfunction
+
+  function automatic logic [31:0] build_i_instr
+    ( input logic [11:0] imm
+    , input logic [4:0]  rs1
+    , input logic [2:0]  funct3
+    , input logic [4:0]  rd
+    , input logic [6:0]  opcode
+    );
+    return {imm, rs1, funct3, rd, opcode};
+  endfunction
+
+  function automatic logic [31:0] build_i_shift_instr
+    ( input logic [6:0] funct7
+    , input logic [4:0] shamt
+    , input logic [4:0] rs1
+    , input logic [2:0] funct3
+    , input logic [4:0] rd
+    , input logic [6:0] opcode
+    );
+    return build_i_instr(.imm({funct7, shamt}), .rs1(rs1), .funct3(funct3), .rd(rd), .opcode(opcode));
+  endfunction
+
+  function automatic logic [31:0] build_s_instr
+    ( input logic [11:0] imm
+    , input logic [4:0]  rs2
+    , input logic [4:0]  rs1
+    , input logic [2:0]  funct3
+    , input logic [6:0]  opcode
+    );
+    return {imm[11:5], rs2, rs1, funct3, imm[4:0], opcode};
+  endfunction
+
+  function automatic logic [31:0] build_b_instr
+    ( input logic [12:0] imm
+    , input logic [4:0]  rs2
+    , input logic [4:0]  rs1
+    , input logic [2:0]  funct3
+    , input logic [6:0]  opcode
+    );
+    return {imm[12], imm[10:5], rs2, rs1, funct3, imm[4:1], imm[11], opcode};
+  endfunction
+
+  function automatic logic [31:0] build_u_instr
+    ( input logic [19:0] imm
+    , input logic [4:0]  rd
+    , input logic [6:0]  opcode
+    );
+    return {imm, rd, opcode};
+  endfunction
+
+  function automatic logic [31:0] build_j_instr
+    ( input logic [20:0] imm
+    , input logic [4:0]  rd
+    , input logic [6:0]  opcode
+    );
+    return {imm[20], imm[10:1], imm[11], imm[19:12], rd, opcode};
+  endfunction
+
   // Note: C.FLW, C.FSW, C.FLD, C.FSD, C.FLWSP, C.FLDSP, C.FSWSP, C.FSDSP should be added alongside future F/D extension support.
   always @(*) begin
     instr_out = NOP;
@@ -44,30 +113,30 @@ module Compressed_Decode
       2'b00: begin // Quadrant 0
         case (funct3)
           3'b000: begin
-            instr_out = {ciw_imm, 5'd2, 3'b000, rd_prime, IType_logic}; // C.ADDI4SPN
+            instr_out = build_i_instr(.imm(ciw_imm), .rs1(5'd2), .funct3(3'b000), .rd(rd_prime), .opcode(IType_logic)); // C.ADDI4SPN
             if (ciw_imm == 12'b0) is_illegal = 1'b1;
           end
-          3'b010: instr_out = {cl_cs_imm, rs1_prime, 3'b010, rd_prime, IType_load}; // C.LW
-          3'b110: instr_out = {cl_cs_imm[11:5], rs2_prime, rs1_prime, 3'b010, cl_cs_imm[4:0], SType}; // C.SW
+          3'b010: instr_out = build_i_instr(.imm(cl_cs_imm), .rs1(rs1_prime), .funct3(3'b010), .rd(rd_prime), .opcode(IType_load)); // C.LW
+          3'b110: instr_out = build_s_instr(.imm(cl_cs_imm), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b010), .opcode(SType)); // C.SW
           default: is_illegal = 1'b1;
         endcase
       end
 
       2'b01: begin // Quadrant 1
         case (funct3)
-          3'b000: instr_out = {ci_imm, rd_full, 3'b000, rd_full, IType_logic}; // C.ADDI
+          3'b000: instr_out = build_i_instr(.imm(ci_imm), .rs1(rd_full), .funct3(3'b000), .rd(rd_full), .opcode(IType_logic)); // C.ADDI
           // TODO C.JAL does not expand exactly to a base RVI instruction since the link address should be pc+2 instead of pc+4
           // Need to add support for offset of 2 bytes and e.g. preserve an is_compressed wire
-          3'b001: instr_out = {cj_imm[20], cj_imm[10:1], cj_imm[11], cj_imm[19:12], 5'd1, JType}; // C.JAL
-          3'b010: instr_out = {ci_imm, 5'd0, 3'b000, rd_full, IType_logic}; // C.LI
+          3'b001: instr_out = build_j_instr(.imm(cj_imm), .rd(5'd1), .opcode(JType)); // C.JAL
+          3'b010: instr_out = build_i_instr(.imm(ci_imm), .rs1(5'd0), .funct3(3'b000), .rd(rd_full), .opcode(IType_logic)); // C.LI
           3'b011: begin
             case (instr_c[11:7])
               5'd2: begin
-                instr_out = {ci_sp_imm, 5'd2, 3'b000, 5'd2, IType_logic}; // C.ADDI16SP
+                instr_out = build_i_instr(.imm(ci_sp_imm), .rs1(5'd2), .funct3(3'b000), .rd(5'd2), .opcode(IType_logic)); // C.ADDI16SP
                 if (ci_sp_imm == 12'b0) is_illegal = 1'b1;
               end
               default: begin
-                instr_out = {ci_lui_imm, rd_full, UType_lui}; // C.LUI
+                instr_out = build_u_instr(.imm(ci_lui_imm), .rd(rd_full), .opcode(UType_lui)); // C.LUI
                 if (ci_lui_imm == 20'b0 ) is_illegal = 1'b1;
               end
             endcase
@@ -75,53 +144,53 @@ module Compressed_Decode
           3'b100: begin
             case (instr_c[11:10])
               2'b00: begin
-                instr_out = {7'h00, instr_c[6:2], rs1_prime, 3'b101, rs1_prime, IType_logic}; // C.SRLI
+                instr_out = build_i_shift_instr(.funct7(7'h00), .shamt(shamt), .rs1(rs1_prime), .funct3(3'b101), .rd(rs1_prime), .opcode(IType_logic)); // C.SRLI
                 if (instr_c[12]) is_illegal = 1'b1;
               end
               2'b01: begin
-                instr_out = {7'h20, instr_c[6:2], rs1_prime, 3'b101, rs1_prime, IType_logic}; // C.SRAI
+                instr_out = build_i_shift_instr(.funct7(7'h20), .shamt(shamt), .rs1(rs1_prime), .funct3(3'b101), .rd(rs1_prime), .opcode(IType_logic)); // C.SRAI
                 if (instr_c[12]) is_illegal = 1'b1;
               end
-              2'b10: instr_out = {ci_imm, rs1_prime, 3'b111, rs1_prime, IType_logic}; // C.ANDI
+              2'b10: instr_out = build_i_instr(.imm(ci_imm), .rs1(rs1_prime), .funct3(3'b111), .rd(rs1_prime), .opcode(IType_logic)); // C.ANDI
               2'b11: begin
                 if (instr_c[12]) is_illegal = 1'b1;
                 case (instr_c[6:5])
-                  2'b00: instr_out = {7'h20, rs2_prime, rs1_prime, 3'b000, rs1_prime, RType}; // C.SUB
-                  2'b01: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b100, rs1_prime, RType}; // C.XOR
-                  2'b10: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b110, rs1_prime, RType}; // C.OR
-                  2'b11: instr_out = {7'h00, rs2_prime, rs1_prime, 3'b111, rs1_prime, RType}; // C.AND
+                  2'b00: instr_out = build_r_instr(.funct7(7'h20), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b000), .rd(rs1_prime), .opcode(RType)); // C.SUB
+                  2'b01: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b100), .rd(rs1_prime), .opcode(RType)); // C.XOR
+                  2'b10: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b110), .rd(rs1_prime), .opcode(RType)); // C.OR
+                  2'b11: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b111), .rd(rs1_prime), .opcode(RType)); // C.AND
                 endcase
               end
               default: instr_out = NOP;
             endcase
           end
-          3'b101: instr_out = {cj_imm[20], cj_imm[10:1], cj_imm[11], cj_imm[19:12], 5'd0, JType}; // C.J
-          3'b110: instr_out = {cb_imm[12], cb_imm[10:5], 5'd0, rs1_prime, 3'b000, cb_imm[4:1], cb_imm[11], BType}; // C.BEQZ
-          3'b111: instr_out = {cb_imm[12], cb_imm[10:5], 5'd0, rs1_prime, 3'b001, cb_imm[4:1], cb_imm[11], BType}; // C.BNEZ
+          3'b101: instr_out = build_j_instr(.imm(cj_imm), .rd(5'd0), .opcode(JType)); // C.J
+          3'b110: instr_out = build_b_instr(.imm(cb_imm), .rs2(5'd0), .rs1(rs1_prime), .funct3(3'b000), .opcode(BType)); // C.BEQZ
+          3'b111: instr_out = build_b_instr(.imm(cb_imm), .rs2(5'd0), .rs1(rs1_prime), .funct3(3'b001), .opcode(BType)); // C.BNEZ
         endcase
       end
 
       2'b10: begin // Quadrant 2
         case (funct3)
           3'b000: begin
-            instr_out = {7'h00, shamt, rd_full, 3'b001, rd_full, IType_logic}; // C.SLLI
+            instr_out = build_i_shift_instr(.funct7(7'h00), .shamt(shamt), .rs1(rd_full), .funct3(3'b001), .rd(rd_full), .opcode(IType_logic)); // C.SLLI
             if (instr_c[12]) is_illegal = 1'b1;
           end
           3'b010: begin
-            instr_out = {ci_lwsp_imm, 5'd2, 3'b010, rd_full, IType_load}; // C.LWSP
+            instr_out = build_i_instr(.imm(ci_lwsp_imm), .rs1(5'd2), .funct3(3'b010), .rd(rd_full), .opcode(IType_load)); // C.LWSP
             if (rd_full == 5'd0) is_illegal = 1'b1;
           end
           3'b100: begin
             case ({instr_c[12], instr_c[11:7] != 5'd0, instr_c[6:2] != 5'd0})
-              3'b010:         instr_out = {12'd0, rs1_full, 3'h0, 5'd0, IType_jalr}; // C.JR
-              3'b011, 3'b001: instr_out = {7'h00, rs2_full, 5'd0, 3'h0, rd_full, RType}; // C.MV
-              3'b100:         instr_out = {12'h001, 5'd0, 3'h0, 5'd0, SYSTEM}; // C.EBREAK
-              3'b110:         instr_out = {12'd0, rs1_full, 3'h0, 5'd1, IType_jalr}; // C.JALR (TODO see note on C.JAL)
-              3'b111, 3'b101: instr_out = {7'h00, rs2_full, rd_full, 3'h0, rd_full, RType}; // C.ADD
+              3'b010:         instr_out = build_i_instr(.imm(12'd0), .rs1(rs1_full), .funct3(3'h0), .rd(5'd0), .opcode(IType_jalr)); // C.JR
+              3'b011, 3'b001: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_full), .rs1(5'd0), .funct3(3'h0), .rd(rd_full), .opcode(RType)); // C.MV
+              3'b100:         instr_out = build_i_instr(.imm(12'h001), .rs1(5'd0), .funct3(3'h0), .rd(5'd0), .opcode(SYSTEM)); // C.EBREAK
+              3'b110:         instr_out = build_i_instr(.imm(12'd0), .rs1(rs1_full), .funct3(3'h0), .rd(5'd1), .opcode(IType_jalr)); // C.JALR (TODO see note on C.JAL)
+              3'b111, 3'b101: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_full), .rs1(rd_full), .funct3(3'h0), .rd(rd_full), .opcode(RType)); // C.ADD
               default: is_illegal = 1'b1;
             endcase
           end
-          3'b110: instr_out = {css_imm[11:5], rs2_full, 5'd2, 3'b010, css_imm[4:0], SType}; // C.SWSP
+          3'b110: instr_out = build_s_instr(.imm(css_imm), .rs2(rs2_full), .rs1(5'd2), .funct3(3'b010), .opcode(SType)); // C.SWSP
           default: is_illegal = 1'b1;
         endcase
       end

--- a/src/ext/c/Compressed_Decode.sv
+++ b/src/ext/c/Compressed_Decode.sv
@@ -108,8 +108,6 @@ module Compressed_Decode
     is_illegal = 1'b0;
 
     case (quadrant) // Opcode
-      2'b11: instr_out = {16'b0, instr_c}; // Not a compressed instruction, just pass through (should not actually happen i think?)
-
       2'b00: begin // Quadrant 0
         case (funct3)
           3'b000: begin
@@ -194,6 +192,8 @@ module Compressed_Decode
           default: is_illegal = 1'b1;
         endcase
       end
+
+      2'b11: is_illegal = 1'b1; // Not a compressed instruction
     endcase
   end
 

--- a/src/ext/c/Compressed_Decode.sv
+++ b/src/ext/c/Compressed_Decode.sv
@@ -9,7 +9,7 @@ module Compressed_Decode
   );
 
   wire [1:0] quadrant = instr_c[1:0];
-  wire [2:0] funct3   = instr_c[15:13];
+  wire [2:0] c_funct3   = instr_c[15:13];
 
   // Common locations of registers in instruction format
   wire [4:0] rd_prime  = {2'b01, instr_c[4:2]};
@@ -18,7 +18,7 @@ module Compressed_Decode
   wire [4:0] rd_full  = instr_c[11:7];
   wire [4:0] rs1_full = instr_c[11:7];
   wire [4:0] rs2_full = instr_c[6:2];
-  wire [4:0] shamt = instr_c[6:2];
+  wire [4:0] c_shamt = instr_c[6:2];
 
   // Pre-compute immediates for each instruction format
   wire [11:0] ciw_imm     = {2'b00, instr_c[10:7], instr_c[12:11], instr_c[5], instr_c[6], 2'b00};
@@ -83,6 +83,7 @@ module Compressed_Decode
     , input logic [2:0]  funct3
     , input logic [6:0]  opcode
     );
+    logic _unused = &{imm[0]};
     return {imm[12], imm[10:5], rs2, rs1, funct3, imm[4:1], imm[11], opcode};
   endfunction
 
@@ -99,6 +100,7 @@ module Compressed_Decode
     , input logic [4:0]  rd
     , input logic [6:0]  opcode
     );
+    logic _unused = &{imm[0]};
     return {imm[20], imm[10:1], imm[11], imm[19:12], rd, opcode};
   endfunction
 
@@ -109,7 +111,7 @@ module Compressed_Decode
 
     case (quadrant) // Opcode
       2'b00: begin // Quadrant 0
-        case (funct3)
+        case (c_funct3)
           3'b000: begin
             instr_out = build_i_instr(.imm(ciw_imm), .rs1(5'd2), .funct3(3'b000), .rd(rd_prime), .opcode(IType_logic)); // C.ADDI4SPN
             if (ciw_imm == 12'b0) is_illegal = 1'b1;
@@ -121,7 +123,7 @@ module Compressed_Decode
       end
 
       2'b01: begin // Quadrant 1
-        case (funct3)
+        case (c_funct3)
           3'b000: instr_out = build_i_instr(.imm(ci_imm), .rs1(rd_full), .funct3(3'b000), .rd(rd_full), .opcode(IType_logic)); // C.ADDI
           // TODO C.JAL does not expand exactly to a base RVI instruction since the link address should be pc+2 instead of pc+4
           // Need to add support for offset of 2 bytes and e.g. preserve an is_compressed wire
@@ -142,11 +144,11 @@ module Compressed_Decode
           3'b100: begin
             case (instr_c[11:10])
               2'b00: begin
-                instr_out = build_i_shift_instr(.funct7(7'h00), .shamt(shamt), .rs1(rs1_prime), .funct3(3'b101), .rd(rs1_prime), .opcode(IType_logic)); // C.SRLI
+                instr_out = build_i_shift_instr(.funct7(7'h00), .shamt(c_shamt), .rs1(rs1_prime), .funct3(3'b101), .rd(rs1_prime), .opcode(IType_logic)); // C.SRLI
                 if (instr_c[12]) is_illegal = 1'b1;
               end
               2'b01: begin
-                instr_out = build_i_shift_instr(.funct7(7'h20), .shamt(shamt), .rs1(rs1_prime), .funct3(3'b101), .rd(rs1_prime), .opcode(IType_logic)); // C.SRAI
+                instr_out = build_i_shift_instr(.funct7(7'h20), .shamt(c_shamt), .rs1(rs1_prime), .funct3(3'b101), .rd(rs1_prime), .opcode(IType_logic)); // C.SRAI
                 if (instr_c[12]) is_illegal = 1'b1;
               end
               2'b10: instr_out = build_i_instr(.imm(ci_imm), .rs1(rs1_prime), .funct3(3'b111), .rd(rs1_prime), .opcode(IType_logic)); // C.ANDI
@@ -169,9 +171,9 @@ module Compressed_Decode
       end
 
       2'b10: begin // Quadrant 2
-        case (funct3)
+        case (c_funct3)
           3'b000: begin
-            instr_out = build_i_shift_instr(.funct7(7'h00), .shamt(shamt), .rs1(rd_full), .funct3(3'b001), .rd(rd_full), .opcode(IType_logic)); // C.SLLI
+            instr_out = build_i_shift_instr(.funct7(7'h00), .shamt(c_shamt), .rs1(rd_full), .funct3(3'b001), .rd(rd_full), .opcode(IType_logic)); // C.SLLI
             if (instr_c[12]) is_illegal = 1'b1;
           end
           3'b010: begin

--- a/src/ext/c/Compressed_Decode.sv
+++ b/src/ext/c/Compressed_Decode.sv
@@ -1,35 +1,78 @@
 `include "src/headers/params.svh"
 `include "src/headers/types.svh"
+`include "src/headers/utils.svh"
 `include "src/timescale.svh"
 
 module Compressed_Decode
-  ( input wire [15:0] instr_c // Compressed input instruction
-  , output reg [31:0] instr_out // Expanded instruction
-  , output reg is_illegal // Illegal or not implemented
+  ( input  wire [15:0] instr_c    // Compressed input instruction
+  , output reg  [31:0] instr_out  // Expanded instruction
+  , output reg         is_illegal // Illegal or not implemented
   );
 
   wire [1:0] quadrant = instr_c[1:0];
-  wire [2:0] c_funct3   = instr_c[15:13];
+  wire [2:0] c_funct3 = instr_c[15:13];
 
-  // Common locations of registers in instruction format
+  // Common register fields
+  // - rd'/rs1'/rs2' are compressed 3-bit register indices mapped to x8..x15 (Table 37).
+  // - full fields use the regular 5-bit register index directly.
   wire [4:0] rd_prime  = {2'b01, instr_c[4:2]};
   wire [4:0] rs1_prime = {2'b01, instr_c[9:7]};
   wire [4:0] rs2_prime = {2'b01, instr_c[4:2]};
-  wire [4:0] rd_full  = instr_c[11:7];
-  wire [4:0] rs1_full = instr_c[11:7];
-  wire [4:0] rs2_full = instr_c[6:2];
-  wire [4:0] c_shamt = instr_c[6:2];
+  wire [4:0] rd_full   =         instr_c[11:7];
+  wire [4:0] rs1_full  =         instr_c[11:7];
+  wire [4:0] rs2_full  =         instr_c[6:2];
+  wire [4:0] c_shamt   =         instr_c[6:2];
 
-  // Pre-compute immediates for each instruction format
-  wire [11:0] ciw_imm     = {2'b00, instr_c[10:7], instr_c[12:11], instr_c[5], instr_c[6], 2'b00};
-  wire [11:0] cl_cs_imm   = {5'b00000, instr_c[5], instr_c[12:10], instr_c[6], 2'b00};
-  wire [11:0] ci_imm      = {{6{instr_c[12]}}, instr_c[12], instr_c[6:2]};
-  wire [11:0] ci_sp_imm   = {{3{instr_c[12]}}, instr_c[4:3], instr_c[5], instr_c[2], instr_c[6], 4'b0000};
-  wire [19:0] ci_lui_imm  = {{14{instr_c[12]}}, instr_c[12], instr_c[6:2]};
-  wire [20:0] cj_imm      = {{9{instr_c[12]}}, instr_c[12], instr_c[8], instr_c[10:9], instr_c[6], instr_c[7], instr_c[2], instr_c[11], instr_c[5:3], 1'b0};
-  wire [12:0] cb_imm      = {{4{instr_c[12]}}, instr_c[12], instr_c[6:5], instr_c[2], instr_c[11:10], instr_c[4:3], 1'b0};
-  wire [11:0] ci_lwsp_imm = {4'b0000, instr_c[3:2], instr_c[12], instr_c[6:4], 2'b00};
-  wire [11:0] css_imm     = {4'b0000, instr_c[8:7], instr_c[12:9], 2'b00};
+  // Decompressed immediates from compressed encodings.
+  // References: Table 36 (formats), Section 28.3/28.4/28.5, Figure 3/4/5 bit listings.
+
+  // as per "28.5.2. Integer Register-Immediate Operations" (C.ADDI4SPN, CIW format)
+  //
+  //                        [   11:10 |           9:6 |           5:4  |          3 |          2 |   1:0 ]
+  wire [11:0] ciw_imm     = { 2'b00   , instr_c[10:7] , instr_c[12:11] , instr_c[5] , instr_c[6] , 2'b00 };
+
+  // as per "28.3.2. Register-Based Loads and Stores" (CL/CS: C.LW, C.SW)
+  //
+  //                        [     11:7 |          6 |            5:3 |          2 |   1:0 ]
+  wire [11:0] cl_cs_imm   = { 5'b00000 , instr_c[5] , instr_c[12:10] , instr_c[6] , 2'b00 };
+
+  // as per "28.5.1/28.5.2" (CI format immediate used by C.ADDI/C.LI/C.ANDI)
+  //
+  //                        [             11:6 |           5 |          4:0 ]
+  wire [11:0] ci_imm      = { {6{instr_c[12]}} , instr_c[12] , instr_c[6:2] };
+
+  // as per "28.5.2. Integer Register-Immediate Operations" (C.ADDI16SP)
+  //
+  //                        [             11:9 |            8 |        7:6 |          5 |          4 |     3:0 ]
+  wire [11:0] ci_sp_imm   = { {3{instr_c[12]}} , instr_c[4:3] , instr_c[5] , instr_c[2] , instr_c[6] , 4'b0000 };
+
+  // as per "28.5.1. Integer Constant-Generation Instructions" (C.LUI)
+  // even though nzimm in the figue in the section specifies ranges [17] and [16:12] we use
+  // [17-12=5] and [16-12=4:12-12=0] since u-type instructions get 12 trailing eros as part of the
+  // base ISA decode
+  //
+  //                        [              19:6 |           5 |          4:0 ]
+  wire [19:0] ci_lui_imm  = { {14{instr_c[12]}} , instr_c[12] , instr_c[6:2] };
+
+  // as per "28.4. Control Transfer Instructions" (CJ format: C.J/C.JAL)
+  //
+  //                        [            20:12 |          11 |        10  |           9:8 |         7  |         6  |         5  |           4 |          3:1 |    0 ]
+  wire [20:0] cj_imm      = { {9{instr_c[12]}} , instr_c[12] , instr_c[8] , instr_c[10:9] , instr_c[6] , instr_c[7] , instr_c[2] , instr_c[11] , instr_c[5:3] , 1'b0 };
+
+  // as per "28.4. Control Transfer Instructions" (CB format: C.BEQZ/C.BNEZ)
+  //
+  //                        [             12:9 |           8 |          7:6 |          5 |            4:3 |          2:1 |    0 ]
+  wire [12:0] cb_imm      = { {4{instr_c[12]}} , instr_c[12] , instr_c[6:5] , instr_c[2] , instr_c[11:10] , instr_c[4:3] , 1'b0 };
+
+  // as per "28.3.1. Stack-Pointer-Based Loads and Stores" (CI format: C.LWSP)
+  //
+  //                        [    11:8 |          7:6 |           5 |          4:2 |   1:0 ]
+  wire [11:0] ci_lwsp_imm = { 4'b0000 , instr_c[3:2] , instr_c[12] , instr_c[6:4] , 2'b00 };
+
+  // as per "28.3.1. Stack-Pointer-Based Loads and Stores" (CSS format: C.SWSP)
+  //
+  //                        [    11:8 |          7:6 |           5:2 |   1:0 ]
+  wire [11:0] css_imm     = { 4'b0000 , instr_c[8:7] , instr_c[12:9] , 2'b00 };
 
   localparam bit [31:0] NOP = 32'h00000013;
 
@@ -63,11 +106,19 @@ module Compressed_Decode
     , input logic [4:0] rd
     , input logic [6:0] opcode
     );
-    return build_i_instr(.imm({funct7, shamt}), .rs1(rs1), .funct3(funct3), .rd(rd), .opcode(opcode));
+    return build_i_instr
+      ( .imm({funct7, shamt})
+      , .rs1(rs1)
+      , .funct3(funct3)
+      , .rd(rd)
+      , .opcode(opcode)
+      );
   endfunction
 
   function automatic logic [31:0] build_s_instr
+    /* verilator lint_off UNUSEDSIGNAL */ /* imm[0] is dropped to force 2-byte alignment */
     ( input logic [11:0] imm
+    /* verilator lint_on UNUSEDSIGNAL */
     , input logic [4:0]  rs2
     , input logic [4:0]  rs1
     , input logic [2:0]  funct3
@@ -77,13 +128,14 @@ module Compressed_Decode
   endfunction
 
   function automatic logic [31:0] build_b_instr
+    /* verilator lint_off UNUSEDSIGNAL */ /* imm[0] is dropped to force 2-byte alignment */
     ( input logic [12:0] imm
+    /* verilator lint_on UNUSEDSIGNAL */
     , input logic [4:0]  rs2
     , input logic [4:0]  rs1
     , input logic [2:0]  funct3
     , input logic [6:0]  opcode
     );
-    logic _unused = &{imm[0]};
     return {imm[12], imm[10:5], rs2, rs1, funct3, imm[4:1], imm[11], opcode};
   endfunction
 
@@ -96,107 +148,143 @@ module Compressed_Decode
   endfunction
 
   function automatic logic [31:0] build_j_instr
+    /* verilator lint_off UNUSEDSIGNAL */ /* imm[0] is dropped to force 2-byte alignment */
     ( input logic [20:0] imm
+    /* verilator lint_on UNUSEDSIGNAL */
     , input logic [4:0]  rd
     , input logic [6:0]  opcode
     );
-    logic _unused = &{imm[0]};
     return {imm[20], imm[10:1], imm[11], imm[19:12], rd, opcode};
   endfunction
 
+  // Docompressed instructions
+
+  // as per Section 28.5.2. "Integer Constant-Generation / Register-Immediate Operations"
+  wire instr_t dec_SRLI     = build_i_shift_instr( .funct7(7'h00) , .shamt(c_shamt) , .rs1(rs1_prime) , .funct3(3'b101) , .rd(rs1_prime) , .opcode(IType_logic) ); // srli rs1', rs1', shamt
+  wire instr_t dec_SRAI     = build_i_shift_instr( .funct7(7'h20) , .shamt(c_shamt) , .rs1(rs1_prime) , .funct3(3'b101) , .rd(rs1_prime) , .opcode(IType_logic) ); // srai rs1', rs1', shamt
+  wire instr_t dec_SLLI     = build_i_shift_instr( .funct7(7'h00) , .shamt(c_shamt) , .rs1(rd_full)   , .funct3(3'b001) , .rd(rd_full)   , .opcode(IType_logic) ); // slli rd, rd, shamt
+
+  // as per Section 28.5.2. "Integer Constant-Generation / Register-Immediate Operations"
+  wire instr_t dec_ANDI     = build_i_instr( .imm(ci_imm) , .rs1(rs1_prime) , .funct3(3'b111) , .rd(rs1_prime) , .opcode(IType_logic) ); // andi rs1', rs1', imm
+
+  // as per Section 28.5.4. "Integer Register-Register Operations"
+  wire instr_t dec_MV       = build_r_instr( .funct7(7'h00) , .rs2(rs2_full)  , .rs1(5'd0)      , .funct3(3'h000) , .rd(rd_full)   , .opcode(RType) ); // mv rd, rs2
+  wire instr_t dec_ADD      = build_r_instr( .funct7(7'h00) , .rs2(rs2_full)  , .rs1(rd_full)   , .funct3(3'h000) , .rd(rd_full)   , .opcode(RType) ); // add rd, rd, rs2
+  wire instr_t dec_SUB      = build_r_instr( .funct7(7'h20) , .rs2(rs2_prime) , .rs1(rs1_prime) , .funct3(3'b000) , .rd(rs1_prime) , .opcode(RType) ); // sub rs1', rs1', rs2'
+  wire instr_t dec_XOR      = build_r_instr( .funct7(7'h00) , .rs2(rs2_prime) , .rs1(rs1_prime) , .funct3(3'b100) , .rd(rs1_prime) , .opcode(RType) ); // xor rs1', rs1', rs2'
+  wire instr_t dec_OR       = build_r_instr( .funct7(7'h00) , .rs2(rs2_prime) , .rs1(rs1_prime) , .funct3(3'b110) , .rd(rs1_prime) , .opcode(RType) ); // or rs1', rs1', rs2'
+  wire instr_t dec_AND      = build_r_instr( .funct7(7'h00) , .rs2(rs2_prime) , .rs1(rs1_prime) , .funct3(3'b111) , .rd(rs1_prime) , .opcode(RType) ); // and rs1', rs1', rs2'
+
+  // as per Section 28.3.1. "Stack-Pointer-Based Loads and Stores"
+  wire instr_t dec_SWSP     = build_s_instr( .imm(css_imm) , .rs2(rs2_full) , .rs1(5'd2) , .funct3(3'b010) , .opcode(SType) ); // sw rs2, offset(sp)
+
+  // as per Section 28.3.1. "Stack-Pointer-Based Loads and Stores"
+  wire instr_t dec_LWSP     = build_i_instr( .imm(ci_lwsp_imm) , .rs1(5'd2) , .funct3(3'b010) , .rd(rd_full) , .opcode(IType_load) ); // lw rd, offset(sp)
+
+  // as per Section 28.3.2. "Register-Based Loads and Stores"
+  wire instr_t dec_SW       = build_s_instr( .imm(cl_cs_imm) , .rs2(rs2_prime) , .rs1(rs1_prime) , .funct3(3'b010) , .opcode(SType) ); // sw rs2′, offset(rs1′)
+
+  // as per Section 28.3.2. "Register-Based Loads and Stores"
+  wire instr_t dec_LW       = build_i_instr( .imm(cl_cs_imm) , .rs1(rs1_prime) , .funct3(3'b010) , .rd(rd_prime) , .opcode(IType_load) ); // lw rd′, offset(rs1′)
+
+  // as per Section 28.4. "Control Transfer Instructions"
+  wire instr_t dec_JAL      = build_j_instr( .imm(cj_imm), .rd(5'd1) , .opcode(JType) ); // jal x1, offset
+  wire instr_t dec_J        = build_j_instr( .imm(cj_imm), .rd(5'd0) , .opcode(JType) ); // jal x0, offset
+
+  // as per Section 28.4. "Control Transfer Instructions"
+  wire instr_t dec_JALR     = build_i_instr( .imm(12'd0) , .rs1(rs1_full) , .funct3(3'h000) , .rd(5'd1) , .opcode(IType_jalr) ); // jalr x1, 0(rs1)
+
+  // as per Section 28.4. "Control Transfer Instructions"
+  wire instr_t dec_BEQZ     = build_b_instr( .imm(cb_imm) , .rs2(5'd0) , .rs1(rs1_prime) , .funct3(3'b000) , .opcode(BType) ); // beq rs1', x0, offset
+  wire instr_t dec_BNEZ     = build_b_instr( .imm(cb_imm) , .rs2(5'd0) , .rs1(rs1_prime) , .funct3(3'b001) , .opcode(BType) ); // bne rs1', x0, offset
+
+  // as per Section 28.5.1. "Integer Constant-Generation Instructions"
+  wire instr_t dec_LUI      = build_u_instr( .imm(ci_lui_imm) , .rd(rd_full) , .opcode(UType_lui) ); // lui rd, imm
+
+  // as per Section 28.5.1. "Integer Constant-Generation Instructions"
+  wire instr_t dec_LI       = build_i_instr( .imm(ci_imm) , .rs1(5'd0)    , .funct3(3'b000) , .rd(rd_full) , .opcode(IType_logic) ); // addi rd, x0, imm
+  wire instr_t dec_ADDI     = build_i_instr( .imm(ci_imm) , .rs1(rd_full) , .funct3(3'b000) , .rd(rd_full) , .opcode(IType_logic) ); // addi rd, rd, imm
+
+  // as per Section 28.5.2. "Integer Register-Immediate Operations"
+  wire instr_t dec_ADDI4SPN = build_i_instr( .imm(ciw_imm)   , .rs1(5'd2) , .funct3(3'b000) , .rd(rd_prime)  , .opcode(IType_logic) ); // addi rd′, x2, nzuimm[9:2]
+  wire instr_t dec_ADDI16SP = build_i_instr( .imm(ci_sp_imm) , .rs1(5'd2) , .funct3(3'b000) , .rd(5'd2)      , .opcode(IType_logic) ); // addi x2, x2, nzimm[9:4]
+
+  // as per Section 28.5.6. "Breakpoint Instruction"
+  wire instr_t dec_EBREAK   = build_i_instr( .imm(12'h001) , .rs1(5'd0) , .funct3(3'h000) , .rd(5'd0) , .opcode(SYSTEM)      ); // ebreak
+
   // Note: C.FLW, C.FSW, C.FLD, C.FSD, C.FLWSP, C.FLDSP, C.FSWSP, C.FSDSP should be added alongside future F/D extension support.
-  always @(*) begin
-    instr_out = NOP;
-    is_illegal = 1'b0;
+  always_comb
+    case (quadrant)
+      2'b00:
+        // Quadrant 0 (Figure 3. Instruction listing for RVC, Quadrant 0)
 
-    case (quadrant) // Opcode
-      2'b00: begin // Quadrant 0
         case (c_funct3)
-          3'b000: begin
-            instr_out = build_i_instr(.imm(ciw_imm), .rs1(5'd2), .funct3(3'b000), .rd(rd_prime), .opcode(IType_logic)); // C.ADDI4SPN
-            if (ciw_imm == 12'b0) is_illegal = 1'b1;
-          end
-          3'b010: instr_out = build_i_instr(.imm(cl_cs_imm), .rs1(rs1_prime), .funct3(3'b010), .rd(rd_prime), .opcode(IType_load)); // C.LW
-          3'b110: instr_out = build_s_instr(.imm(cl_cs_imm), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b010), .opcode(SType)); // C.SW
-          default: is_illegal = 1'b1;
+          3'b000:             {instr_out, is_illegal} = {dec_ADDI4SPN    , ciw_imm == 12'b0   };
+          3'b010:             {instr_out, is_illegal} = {dec_LW          , `FALSE             };
+          3'b110:             {instr_out, is_illegal} = {dec_SW          , `FALSE             };
+
+          // RV32C subset implemented here: floating-point and RV64C opcodes are treated as illegal.
+          default:            {instr_out, is_illegal} = {instr_t'(0)     , `FALSE             };
         endcase
-      end
 
-      2'b01: begin // Quadrant 1
+      2'b01:
+        // Quadrant 1 (Figure 4. Instruction listing for RVC, Quadrant 1)
+
         case (c_funct3)
-          3'b000: instr_out = build_i_instr(.imm(ci_imm), .rs1(rd_full), .funct3(3'b000), .rd(rd_full), .opcode(IType_logic)); // C.ADDI
-          // TODO C.JAL does not expand exactly to a base RVI instruction since the link address should be pc+2 instead of pc+4
-          // Need to add support for offset of 2 bytes and e.g. preserve an is_compressed wire
-          3'b001: instr_out = build_j_instr(.imm(cj_imm), .rd(5'd1), .opcode(JType)); // C.JAL
-          3'b010: instr_out = build_i_instr(.imm(ci_imm), .rs1(5'd0), .funct3(3'b000), .rd(rd_full), .opcode(IType_logic)); // C.LI
-          3'b011: begin
+          3'b000:             {instr_out, is_illegal} = {dec_ADDI        , `FALSE             };
+          3'b001:
+            // TODO: C.JAL does not expand exactly to a base RVI instruction since the link address
+            // should be pc+2 instead of pc+4 Need to add support for offset of 2 bytes and e.g.
+            // preserve an is_compressed wire
+                              {instr_out, is_illegal} = {dec_JAL         , `FALSE             };
+          3'b010:             {instr_out, is_illegal} = {dec_LI          , `FALSE             };
+          3'b011:
             case (instr_c[11:7])
-              5'd2: begin
-                instr_out = build_i_instr(.imm(ci_sp_imm), .rs1(5'd2), .funct3(3'b000), .rd(5'd2), .opcode(IType_logic)); // C.ADDI16SP
-                if (ci_sp_imm == 12'b0) is_illegal = 1'b1;
-              end
-              default: begin
-                instr_out = build_u_instr(.imm(ci_lui_imm), .rd(rd_full), .opcode(UType_lui)); // C.LUI
-                if (ci_lui_imm == 20'b0 ) is_illegal = 1'b1;
-              end
+              5'd2:           {instr_out, is_illegal} = {dec_ADDI16SP    , ci_sp_imm == 12'b0 };
+              // TODO: handle 5'd0 as per 28.1.5.1 -- "The code points with rd=x0 and imm≠0 are
+              // HINTs."
+              default:        {instr_out, is_illegal} = {dec_LUI         , ci_lui_imm == 20'b0};
             endcase
-          end
-          3'b100: begin
+          3'b100:
             case (instr_c[11:10])
-              2'b00: begin
-                instr_out = build_i_shift_instr(.funct7(7'h00), .shamt(c_shamt), .rs1(rs1_prime), .funct3(3'b101), .rd(rs1_prime), .opcode(IType_logic)); // C.SRLI
-                if (instr_c[12]) is_illegal = 1'b1;
-              end
-              2'b01: begin
-                instr_out = build_i_shift_instr(.funct7(7'h20), .shamt(c_shamt), .rs1(rs1_prime), .funct3(3'b101), .rd(rs1_prime), .opcode(IType_logic)); // C.SRAI
-                if (instr_c[12]) is_illegal = 1'b1;
-              end
-              2'b10: instr_out = build_i_instr(.imm(ci_imm), .rs1(rs1_prime), .funct3(3'b111), .rd(rs1_prime), .opcode(IType_logic)); // C.ANDI
-              2'b11: begin
-                if (instr_c[12]) is_illegal = 1'b1;
+              2'b00:          {instr_out, is_illegal} = {dec_SRLI        , instr_c[12]        };
+              2'b01:          {instr_out, is_illegal} = {dec_SRAI        , instr_c[12]        };
+              2'b10:          {instr_out, is_illegal} = {dec_ANDI        , `FALSE             };
+              2'b11:
                 case (instr_c[6:5])
-                  2'b00: instr_out = build_r_instr(.funct7(7'h20), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b000), .rd(rs1_prime), .opcode(RType)); // C.SUB
-                  2'b01: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b100), .rd(rs1_prime), .opcode(RType)); // C.XOR
-                  2'b10: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b110), .rd(rs1_prime), .opcode(RType)); // C.OR
-                  2'b11: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_prime), .rs1(rs1_prime), .funct3(3'b111), .rd(rs1_prime), .opcode(RType)); // C.AND
+                  2'b00:      {instr_out, is_illegal} = {dec_SUB         , instr_c[12]        };
+                  2'b01:      {instr_out, is_illegal} = {dec_XOR         , instr_c[12]        };
+                  2'b10:      {instr_out, is_illegal} = {dec_OR          , instr_c[12]        };
+                  2'b11:      {instr_out, is_illegal} = {dec_AND         , instr_c[12]        };
                 endcase
-              end
-              default: instr_out = NOP;
+              default:        {instr_out, is_illegal} = {instr_t'(NOP)   , `FALSE             };
             endcase
-          end
-          3'b101: instr_out = build_j_instr(.imm(cj_imm), .rd(5'd0), .opcode(JType)); // C.J
-          3'b110: instr_out = build_b_instr(.imm(cb_imm), .rs2(5'd0), .rs1(rs1_prime), .funct3(3'b000), .opcode(BType)); // C.BEQZ
-          3'b111: instr_out = build_b_instr(.imm(cb_imm), .rs2(5'd0), .rs1(rs1_prime), .funct3(3'b001), .opcode(BType)); // C.BNEZ
+          3'b101:             {instr_out, is_illegal} = {dec_J           , `FALSE             };
+          3'b110:             {instr_out, is_illegal} = {dec_BEQZ        , `FALSE             };
+          3'b111:             {instr_out, is_illegal} = {dec_BNEZ        , `FALSE             };
         endcase
-      end
 
-      2'b10: begin // Quadrant 2
+      2'b10:
+        // Quadrant 2 (Figure 5. Instruction listing for RVC, Quadrant 2)
+
         case (c_funct3)
-          3'b000: begin
-            instr_out = build_i_shift_instr(.funct7(7'h00), .shamt(c_shamt), .rs1(rd_full), .funct3(3'b001), .rd(rd_full), .opcode(IType_logic)); // C.SLLI
-            if (instr_c[12]) is_illegal = 1'b1;
-          end
-          3'b010: begin
-            instr_out = build_i_instr(.imm(ci_lwsp_imm), .rs1(5'd2), .funct3(3'b010), .rd(rd_full), .opcode(IType_load)); // C.LWSP
-            if (rd_full == 5'd0) is_illegal = 1'b1;
-          end
-          3'b100: begin
+          3'b000:             {instr_out, is_illegal} = {dec_SLLI        , instr_c[12]        };
+          3'b010:             {instr_out, is_illegal} = {dec_LWSP        , rd_full == 5'd0    };
+          3'b100:
+            // Figure 5 CR encodings: JR/MV/EBREAK/JALR/ADD are selected by {bit12, rs1!=0, rs2!=0}.
             case ({instr_c[12], instr_c[11:7] != 5'd0, instr_c[6:2] != 5'd0})
-              3'b010:         instr_out = build_i_instr(.imm(12'd0), .rs1(rs1_full), .funct3(3'h0), .rd(5'd0), .opcode(IType_jalr)); // C.JR
-              3'b011, 3'b001: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_full), .rs1(5'd0), .funct3(3'h0), .rd(rd_full), .opcode(RType)); // C.MV
-              3'b100:         instr_out = build_i_instr(.imm(12'h001), .rs1(5'd0), .funct3(3'h0), .rd(5'd0), .opcode(SYSTEM)); // C.EBREAK
-              3'b110:         instr_out = build_i_instr(.imm(12'd0), .rs1(rs1_full), .funct3(3'h0), .rd(5'd1), .opcode(IType_jalr)); // C.JALR (TODO see note on C.JAL)
-              3'b111, 3'b101: instr_out = build_r_instr(.funct7(7'h00), .rs2(rs2_full), .rs1(rd_full), .funct3(3'h0), .rd(rd_full), .opcode(RType)); // C.ADD
-              default: is_illegal = 1'b1;
+              3'b010:         {instr_out, is_illegal} = {dec_J           , `FALSE             };
+              3'b011, 3'b001: {instr_out, is_illegal} = {dec_MV          , `FALSE             };
+              3'b100:         {instr_out, is_illegal} = {dec_EBREAK      , `FALSE             };
+              3'b110:         {instr_out, is_illegal} = {dec_JALR        , `FALSE             };
+              3'b111, 3'b101: {instr_out, is_illegal} = {dec_ADD         , `FALSE             };
+              default:        {instr_out, is_illegal} = {instr_t'(0)     , `TRUE              };
             endcase
-          end
-          3'b110: instr_out = build_s_instr(.imm(css_imm), .rs2(rs2_full), .rs1(5'd2), .funct3(3'b010), .opcode(SType)); // C.SWSP
-          default: is_illegal = 1'b1;
+          3'b110:             {instr_out, is_illegal} = {dec_SWSP        , `FALSE             };
+          default:            {instr_out, is_illegal} = {instr_t'(0)     , `TRUE              };
         endcase
-      end
 
-      2'b11: is_illegal = 1'b1; // Not a compressed instruction
+      2'b11: is_illegal = 1'b1; // Per Table 39, quadrant 3 is >16b and not an RVC opcode.
     endcase
-  end
 
 endmodule

--- a/src/ext/c/Compressed_Decode.sv
+++ b/src/ext/c/Compressed_Decode.sv
@@ -224,7 +224,7 @@ module Compressed_Decode
           3'b110:             {instr_out, is_illegal} = {dec_SW          , `FALSE             };
 
           // RV32C subset implemented here: floating-point and RV64C opcodes are treated as illegal.
-          default:            {instr_out, is_illegal} = {instr_t'(0)     , `FALSE             };
+          default:            {instr_out, is_illegal} = {instr_t'(0)     , `TRUE             };
         endcase
 
       2'b01:
@@ -284,7 +284,8 @@ module Compressed_Decode
           default:            {instr_out, is_illegal} = {instr_t'(0)     , `TRUE              };
         endcase
 
-      2'b11: is_illegal = 1'b1; // Per Table 39, quadrant 3 is >16b and not an RVC opcode.
+      // Per Table 39, quadrant 3 is >16b and not an RVC opcode.
+      2'b11:                  {instr_out, is_illegal} = {instr_t'(0)     , `TRUE              };
     endcase
 
 endmodule

--- a/src/ext/c/decoder.sv
+++ b/src/ext/c/decoder.sv
@@ -3,7 +3,9 @@
 `include "src/headers/utils.svh"
 `include "src/timescale.svh"
 
-module Compressed_Decode
+/* verilator lint_off DECLFILENAME */
+module ext__c__decoder
+/* verilator lint_on DECLFILENAME */
   ( input  wire [15:0] instr_c    // Compressed input instruction
   , output reg  [31:0] instr_out  // Expanded instruction
   , output reg         is_illegal // Illegal or not implemented

--- a/src/headers/params.svh
+++ b/src/headers/params.svh
@@ -13,6 +13,7 @@ parameter UType_auipc = 7'b0010111;
 parameter UType_lui = 7'b0110111;
 parameter IType_jalr = 7'b1100111;
 parameter FENCE    = 7'b0001111;
+parameter SYSTEM = 7'b1110011;
 /* verilator lint_on UNUSEDPARAM */
 
 //ALU Operation Control Codes: Implemented as ENUM in params.svh

--- a/test/c_extension_tb.sv
+++ b/test/c_extension_tb.sv
@@ -1,0 +1,145 @@
+`include "src/timescale.svh"
+
+`include "test/utils.svh"
+
+module c_extension_tb;
+
+  logic [15:0] instr_c;
+  logic [31:0] instr_out;
+  logic is_illegal;
+
+  logic [4:0] rd  = 5'b00001;
+  logic [4:0] rs1 = 5'b00010;
+  logic [4:0] rs2 = 5'b00100;
+
+  logic [31:0] imm;
+
+  Compressed_Decode uut
+    ( .instr_c    ( instr_c    )
+    , .instr_out  ( instr_out  )
+    , .is_illegal ( is_illegal )
+    );
+
+  initial begin
+
+    // C.LUI expands to lui rd, imm
+    // C.LUI format: {funct3, imm[17], rd, imm[16:12], opcode}
+    imm = {15'b0, 5'b10101, 12'b0};
+    instr_c = {3'b011, imm[17], rd, imm[16:12], 2'b01};
+    #10
+    // LUI format: {imm[31:12], rd, opcode[6:0]}
+    `assert_equal(instr_out, {imm[31:12], rd, 7'b0110111})
+    `assert_equal(is_illegal, 1'b0)
+
+    // Test C.LUI with sign extension
+    imm = {15'b111111111111111, 5'b10101, 12'b0};
+    instr_c = {3'b011, imm[17], rd, imm[16:12], 2'b01};
+    #10
+    // LUI format: {imm[31:12], rd, opcode[6:0]}
+    `assert_equal(instr_out, {imm[31:12], rd, 7'b0110111})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.SLLI expands to slli rd, rd, shamt[5:0]
+    // C.SLLI format: {funct3, shamt[5], rd, shamt[4:0], opcode}
+    imm = {26'b0, 6'b001010};
+    instr_c = {3'b000, imm[5], rd, imm[4:0], 2'b10};
+    #10
+    // SLLI format: {imm[11:0], rs1, funct3, rd, opcode}
+    `assert_equal(instr_out, {imm[11:0], rd, 3'h1, rd, 7'b0010011})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.ADDI4SPN expands to addi rd', x2, nzuimm
+    // C.ADDI4SPN format: {funct3, nzuimm[5:4], nzuimm[9:6], nzuimm[2], nzuimm[3], rd', opcode}
+    imm = {22'b0, 8'b00101001, 2'b00};
+    instr_c = {3'b000, imm[5:4], imm[9:6], imm[2], imm[3], rd[2:0], 2'b00};
+    #10
+    // ADDI format: {imm[11:0], rs1, funct3, rd, opcode}
+    `assert_equal(instr_out, {imm[11:0], 5'b00010, 3'h0, {2'b01, rd[2:0]}, 7'b0010011})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.LW expands to lw rd', uimm(rs1')
+    // C.LW format: {funct3, uimm[5:3], rs1', uimm[2], uimm[6], rd', opcode}
+    imm = {25'b0, 5'b10101, 2'b00};
+    instr_c = {3'b010, imm[5:3], rs1[2:0], imm[2], imm[6], rd[2:0], 2'b00};
+    #10
+    // LW format: {imm[11:0], rs1, funct3, rd, opcode}
+    `assert_equal(instr_out, {imm[11:0], {2'b01, rs1[2:0]}, 3'h2, {2'b01, rd[2:0]}, 7'b0000011})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.SW expands to sw rs2', uimm(rs1')
+    // C.SW format: {funct3, uimm[5:3], rs1', uimm[2], uimm[6], rs2', opcode}
+    imm = {25'b0, 5'b11101, 2'b00};
+    instr_c = {3'b110, imm[5:3], rs1[2:0], imm[2], imm[6], rs2[2:0], 2'b00};
+    #10
+    // SW format: {imm[11:5], rs2, rs1, funct3, imm[4:0], opcode}
+    `assert_equal(instr_out, {imm[11:5], {2'b01, rs2[2:0]}, {2'b01, rs1[2:0]}, 3'h2, imm[4:0], 7'b0100011})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.XOR expands to xor rd', rd', rs2'
+    // C.XOR format: {funct6, rd'/rs1', funct2, rs2', opcode}
+    instr_c = {6'b100011, rd[2:0], 2'b01, rs2[2:0], 2'b01};
+    #10
+    // XOR format: {funct7, rs2, rs1, funct3, rd, opcode}
+    `assert_equal(instr_out, {7'b0000000, {2'b01, rs2[2:0]}, {2'b01, rd[2:0]}, 3'h4, {2'b01, rd[2:0]}, 7'b0110011})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.MV expands to add rd, x0, rs2
+    // C.MV format: {funct3, 1'b0, rd, rs2, opcode}
+    instr_c = {3'b100, 1'b0, rd, rs2, 2'b10};
+    #10
+    // ADD format: {funct7, rs2, rs1, funct3, rd, opcode}
+    `assert_equal(instr_out, {7'b0000000, rs2, 5'b00000, 3'h0, rd, 7'b0110011})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.BEQZ expands to beq rs1', x0, offset
+    // C.BEQZ format: {funct3, offset[8], offset[4:3], rs1', offset[7:6], offset[2:1], offset[5], opcode}
+    imm = {19'b0, 12'b00000101011, 1'b0};
+    instr_c = {3'b110, imm[8], imm[4:3], rs1[2:0], imm[7:6], imm[2:1], imm[5], 2'b01};
+    #10
+    // BEQ format: {imm[12], imm[10:5], rs2, rs1, funct3, imm[4:1], imm[11], opcode}
+    `assert_equal(instr_out, {imm[12], imm[10:5], 5'b00000, {2'b01, rs1[2:0]}, 3'h0, imm[4:1], imm[11], 7'b1100011})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.J expands to jal x0, offset
+    // C.J format: {funct3, offset[11], offset[4], offset[9:8], offset[10], offset[6], offset[7], offset[3:1], offset[5], opcode}
+    imm = {11'b0, 20'b0000000000101010101, 1'b0};
+    instr_c = {3'b101, imm[11], imm[4], imm[9:8], imm[10], imm[6], imm[7], imm[3:1], imm[5], 2'b01};
+    #10
+    // JAL format: {imm[20], imm[10:1], imm[11], imm[19:12], rd, opcode}
+    `assert_equal(instr_out, {imm[20], imm[10:1], imm[11], imm[19:12], 5'b00000, 7'b1101111})
+    `assert_equal(is_illegal, 1'b0)
+
+    // C.SWSP expands to sw rs2, uimm(x2)
+    // C.SWSP format: {funct3, uimm[5:2], uimm[7:6], rs2, opcode}
+    imm = {24'b0, 6'b010111, 2'b00};
+    instr_c = {3'b110, imm[5:2], imm[7:6], rs2, 2'b10};
+    #10
+    // SW format: {imm[11:5], rs2, rs1, funct3, imm[4:0], opcode}
+    `assert_equal(instr_out, {imm[11:5], rs2, 5'b00010, 3'h2, imm[4:0], 7'b0100011})
+    `assert_equal(is_illegal, 1'b0)
+
+    // Illegal: C.ADDI4SPN with nzuimm = 0 is reserved
+    imm = {32'b0};
+    instr_c = {3'b000, imm[9:2], rd[2:0], 2'b00};
+    #10
+    `assert_equal(is_illegal, 1'b1)
+
+    // Illegal: C.LWSP with rd = x0 is reserved
+    imm = {24'b0, 6'b001011, 2'b00};
+    instr_c = {3'b010, imm[5], 5'b00000, imm[4:2], imm[7:6], 2'b10};
+    #10
+    `assert_equal(is_illegal, 1'b1)
+
+    // Illegal: C.JR with rs1 = x0 is reserved
+    instr_c = {3'b100, 1'b0, 5'b00000, 5'b00000, 2'b10};
+    #10
+    `assert_equal(is_illegal, 1'b1)
+
+    $finish;
+  end
+
+  wire _unused = &{rd, rs1, rs2, imm};
+
+  `SETUP_VCD_DUMP(c_extension_tb)
+
+endmodule

--- a/test/c_extension_tb.sv
+++ b/test/c_extension_tb.sv
@@ -14,7 +14,7 @@ module c_extension_tb;
 
   logic [31:0] imm;
 
-  Compressed_Decode uut
+  ext__c__decoder uut
     ( .instr_c    ( instr_c    )
     , .instr_out  ( instr_out  )
     , .is_illegal ( is_illegal )


### PR DESCRIPTION
Issue #239

Implemented decompression for all rv32 instructions other than F and D extension ones

Also added checking for illegal/reserved and unimplemented instructions though I don't think we have a way to handle that properly yet?

Note C.JAL and C.JALR need extra handling to work properly (I think)

