### PR TITLE
CSR hazard stall

### DIFF
--- a/src/hazard_unit.sv
+++ b/src/hazard_unit.sv
@@ -15,6 +15,16 @@ module hazard_unit
   , input  wire [4:0] rs2_d
   , input  wire [4:0] rd_e
   , input  pc_src_t pc_src_e
+  `ifdef UTOSS_RISCV__ZICSR_ENABLED
+  , input  logic      csr_instr_d
+  , input  logic      csr_write_intent_e
+  , input  logic      csr_write_intent_m
+  , input  logic      csr_write_intent_w
+  , input  csr_addr_t csr_addr_d
+  , input  csr_addr_t csr_addr_e
+  , input  csr_addr_t csr_addr_m
+  , input  csr_addr_t csr_addr_w
+`endif
   , output hazard_forward_a_t forward_a_e
   , output hazard_forward_b_t forward_b_e
   , output logic stall_f
@@ -23,11 +33,6 @@ module hazard_unit
   , output logic flush_d
   , output logic flush_e
   );
-
-  wire result_src_e_0;
-  assign result_src_e_0 = result_src_e[0];
-
-  wire unused = &{result_src_e[$bits(result_src_t) -1:1]};
 
   // Forwarding
   always_comb
@@ -49,9 +54,24 @@ module hazard_unit
   logic lw_stall;
 
   //Stall when a load hazard occurs
-  assign lw_stall = result_src_e_0 && ((rs1_d == rd_e) || (rs2_d == rd_e)) && (rd_e != 5'd0);
-  assign stall_f = lw_stall;
-  assign stall_d = lw_stall;
+  assign lw_stall = (result_src_e == RESULT_SRC__READ_DATA)
+                 && ((rs1_d == rd_e) || (rs2_d == rd_e))
+                 && (rd_e != 5'd0);
+    logic csr_stall;
+//CSR stall for csr-to-csr stall
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+  assign csr_stall =
+      csr_instr_d &&
+      ((csr_write_intent_e && (csr_addr_d == csr_addr_e)) ||
+       (csr_write_intent_m && (csr_addr_d == csr_addr_m)) ||
+       (csr_write_intent_w && (csr_addr_d == csr_addr_w)));
+`else
+  assign csr_stall = 1'b0;
+`endif
+
+  assign stall_f = lw_stall||csr_stall;
+  assign stall_d = lw_stall||csr_stall;
+
 
   //Flush when a control hazard occurs; we need to flush one cycle later than we discover the
   // control hazard; this is due to synchronous memory making the instruction available one cycle
@@ -64,6 +84,6 @@ module hazard_unit
 
   assign flush_f = control_hazard;
   assign flush_d = control_hazard;
-  assign flush_e = lw_stall || control_hazard;
+  assign flush_e = lw_stall ||csr_stall || control_hazard;
 
 endmodule

--- a/src/headers/params.svh
+++ b/src/headers/params.svh
@@ -13,6 +13,7 @@ parameter UType_auipc = 7'b0010111;
 parameter UType_lui = 7'b0110111;
 parameter IType_jalr = 7'b1100111;
 parameter FENCE    = 7'b0001111;
+parameter SYSTEM   = 7'b1110011;
 /* verilator lint_on UNUSEDPARAM */
 
 //ALU Operation Control Codes: Implemented as ENUM in params.svh

--- a/src/headers/types.svh
+++ b/src/headers/types.svh
@@ -8,6 +8,7 @@ typedef logic [`PROCESSOR_BITNESS -1:0] instr_t;
 typedef logic [`PROCESSOR_BITNESS -1:0] addr_t;
 typedef logic [`PROCESSOR_BITNESS -1:0] imm_t;
 typedef logic [`PROCESSOR_BITNESS -1:0] data_t;
+typedef logic [11:0] csr_addr_t;
 
 typedef logic [6:0] opcode_t;
 
@@ -57,6 +58,7 @@ typedef enum logic [1:0]
   { RESULT_SRC__ALU_RESULT = 2'b00
   , RESULT_SRC__READ_DATA  = 2'b01
   , RESULT_SRC__PC_PLUS_4  = 2'b10
+  , RESULT_SRC__CSR_READ   = 2'b11
   } result_src_t;
 
 typedef enum logic

--- a/src/interfaces/ex_to_mem_if.svh
+++ b/src/interfaces/ex_to_mem_if.svh
@@ -10,6 +10,7 @@ typedef struct packed {
   result_src_t result_src;
   data_t       alu_result;
   data_t       write_data_e;
+  data_t       csr_read_data;
   logic [2:0]  funct3;
   logic [4:0]  rd;
   addr_t       pc_cur;

--- a/src/interfaces/id_to_ex_if.svh
+++ b/src/interfaces/id_to_ex_if.svh
@@ -17,6 +17,7 @@ typedef struct packed {
   logic         reg_write;
   alu_control_t alu_control;
   logic [2:0]   funct3;
+  data_t        csr_read_data;
   data_t        rd1;
   data_t        rd2;
   logic [4:0]   rd;

--- a/src/interfaces/mem_to_wb_if.svh
+++ b/src/interfaces/mem_to_wb_if.svh
@@ -5,6 +5,7 @@ typedef struct packed {
   result_src_t result_src;
   logic        reg_write;
   data_t       alu_result;
+  data_t       csr_read_data;
   logic [4:0]  rd;
   addr_t       pc_cur;
   addr_t       pc_plus_4;

--- a/src/modules/CSR/CSRFile.sv
+++ b/src/modules/CSR/CSRFile.sv
@@ -1,0 +1,28 @@
+`include "src/timescale.svh"
+`include "src/headers/types.svh"
+
+module CSRFile
+  ( input  csr_addr_t addr
+  , input  logic      clk
+  , input  logic      reset
+  , input  logic      csr_write_enable
+  , input  data_t     data_in
+  , output data_t     data_out
+  );
+
+  reg [31:0] CSRMem [0:4095] /* synthesis ramstyle = M10K */;
+
+  assign data_out = CSRMem[addr];
+
+  always @(posedge clk) begin
+    if (reset) begin
+      integer i;
+      for (i = 0; i < 4096; i = i + 1) begin
+        CSRMem[i] <= 32'b0;
+      end
+    end else if (csr_write_enable) begin
+      CSRMem[addr] <= data_in;
+    end
+  end
+
+endmodule

--- a/src/modules/ControlFSM.sv
+++ b/src/modules/ControlFSM.sv
@@ -6,6 +6,7 @@
 module control_fsm
 /* verilator lint_off DECLFILENAME */
   ( input opcode_t opcode
+  , input logic [2:0] funct3
 
   , output var logic        reg_write
   , output result_src_t     result_src
@@ -26,7 +27,11 @@ module control_fsm
       (opcode == IType_logic) ||
       (opcode == IType_jalr) ||
       (opcode == UType_auipc) ||
-      (opcode == UType_lui);
+      (opcode == UType_lui)
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+      || ((opcode == SYSTEM) && (funct3 inside {3'b001, 3'b010, 3'b011}))
+`endif
+      ;
 
   always_comb
     case (opcode)
@@ -36,6 +41,13 @@ module control_fsm
         result_src = RESULT_SRC__READ_DATA;
       JType, IType_jalr:
         result_src = RESULT_SRC__PC_PLUS_4;
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+      SYSTEM:
+        if (funct3 inside {3'b001, 3'b010, 3'b011})
+          result_src = RESULT_SRC__CSR_READ;
+        else
+          result_src = result_src_t'('0);
+`endif
       default:
         result_src = result_src_t'('0);
     endcase
@@ -59,6 +71,10 @@ module control_fsm
         alu_src_a = ALU_SRC_A__RD1;
       UType_auipc, JType:
         alu_src_a = ALU_SRC_A__PC;
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+      SYSTEM:
+        alu_src_a = ALU_SRC_A__RD1;
+`endif
       default:
         alu_src_a = alu_src_a_t'('x);
     endcase
@@ -69,6 +85,10 @@ module control_fsm
         alu_src_b = ALU_SRC_B__RD2;
       UType_auipc, UType_lui, IType_logic, IType_jalr, IType_load, SType:
         alu_src_b = ALU_SRC_B__IMM_EXT;
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+      SYSTEM:
+        alu_src_b = ALU_SRC_B__IMM_EXT;
+`endif
       default:
         alu_src_b = alu_src_b_t'('x);
     endcase

--- a/src/modules/Instruction_Decode/Instruction_Decode.sv
+++ b/src/modules/Instruction_Decode/Instruction_Decode.sv
@@ -7,6 +7,7 @@ module Instruction_Decode
   , output opcode_t opcode
   , output alu_control_t ALUControl
   , output imm_t imm_ext
+  , output csr_addr_t csr_addr
   , output reg [2:0] funct3
   , output reg [4:0] rd
   , output reg [4:0] rs1
@@ -50,6 +51,11 @@ module Instruction_Decode
       funct3 = instr[14:12];
 
     end
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+    SYSTEM: begin
+      funct3 = instr[14:12];
+    end
+`endif
     default:;
     endcase
   end
@@ -66,6 +72,9 @@ module Instruction_Decode
       UType_auipc: alu_op = ALU_OP__ADD; // used to add 0 to imm ext
       UType_lui:   alu_op = ALU_OP__ADD; // used to add 0 to imm ext
       FENCE:     alu_op = ALU_OP__UNSET;
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+      SYSTEM:    alu_op = ALU_OP__ADD;
+`endif
       default:    alu_op = ALU_OP__UNSET;
     endcase
   end
@@ -96,6 +105,13 @@ module Instruction_Decode
 
       end
 
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+      SYSTEM: begin
+        rd  = instr[11:7];
+        rs1 = instr[19:15];
+      end
+`endif
+
       SType, BType: begin //S-type and B-Type
         rs1 = instr[19:15];
         rs2 = instr[24:20];
@@ -113,6 +129,9 @@ module Instruction_Decode
       end
     endcase
   end
+
+  always_comb
+    csr_addr = (opcode == SYSTEM) ? csr_addr_t'(instr[31:20]) : csr_addr_t'('0);
 
   // case statement for choosing 32-bit immediate format; based on opcode
     // this is essentially the extend module of the processor

--- a/src/modules/Logger.sv
+++ b/src/modules/Logger.sv
@@ -146,6 +146,18 @@ module Logger
             UType_lui:   op_name = "lui";
             IType_jalr:  op_name = "jalr";
             FENCE:       op_name = "fence";
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+            SYSTEM:
+                case (funct3)
+                    3'b001: op_name = "csrrw";
+                    3'b010: op_name = "csrrs";
+                    3'b011: op_name = "csrrc";
+                    3'b101: op_name = "csrrwi";
+                    3'b110: op_name = "csrrsi";
+                    3'b111: op_name = "csrrci";
+                    default:;
+                endcase
+`endif
             default:;
         endcase
     endfunction

--- a/src/stages/decode_stage.sv
+++ b/src/stages/decode_stage.sv
@@ -33,6 +33,8 @@ module decode_stage
 
   opcode_t opcode;
   imm_t    imm_ext;
+  csr_addr_t csr_addr;
+  data_t   csr_read_data;
 
   wire [2:0] funct3;
 
@@ -47,6 +49,7 @@ module decode_stage
 
   control_fsm u_ctrl
     ( .opcode  ( opcode )
+    , .funct3  ( funct3 )
 
     , .reg_write      ( cfsm__reg_write      )
     , .result_src     ( cfsm__result_src     )
@@ -64,6 +67,7 @@ module decode_stage
     , .funct3          ( funct3           )
     , .ALUControl      ( alu_control      )
     , .imm_ext         ( imm_ext          )
+    , .csr_addr        ( csr_addr         )
     , .rd              ( rd               )
     , .rs1             ( rs1              )
     , .rs2             ( rs2              )
@@ -80,6 +84,48 @@ module decode_stage
     , .baseAddr        ( rd1              )
     , .writeData       ( rd2              )
     );
+
+`ifdef UTOSS_RISCV__ZICSR_ENABLED
+  data_t csr_write_data;
+  logic  csr_write_enable;
+
+  CSRFile u_csr_file
+    ( .addr            ( csr_addr         )
+    , .clk             ( clk              )
+    , .reset           ( reset            )
+    , .csr_write_enable( csr_write_enable )
+    , .data_in         ( csr_write_data   )
+    , .data_out        ( csr_read_data    )
+    );
+
+  always_comb begin
+    csr_write_enable = 1'b0;
+    csr_write_data   = data_t'(0);
+
+    if (opcode == SYSTEM) begin
+      case (funct3)
+        3'b001: begin
+          csr_write_enable = 1'b1;
+          csr_write_data   = rd1_safe;
+        end
+        3'b010: begin
+          csr_write_enable = (rs1 != 5'd0);
+          csr_write_data   = csr_read_data | rd1_safe;
+        end
+        3'b011: begin
+          csr_write_enable = (rs1 != 5'd0);
+          csr_write_data   = csr_read_data & ~rd1_safe;
+        end
+        default: begin
+          csr_write_enable = 1'b0;
+          csr_write_data   = data_t'(0);
+        end
+      endcase
+    end
+  end
+`else
+  assign csr_read_data = data_t'(0);
+`endif
 
   // WB->ID bypass; this is needed in situations where decode is reading the register that
   // write-back stage is about to write to; since register writes happen on clock enge without this
@@ -106,6 +152,7 @@ module decode_stage
   assign id_to_ex.reg_write      = cfsm__reg_write;
   assign id_to_ex.alu_control    = alu_control;
   assign id_to_ex.funct3         = funct3;
+  assign id_to_ex.csr_read_data  = csr_read_data;
   assign id_to_ex.rd1            = rd1_safe;
   assign id_to_ex.rd2            = rd2_safe;
   assign id_to_ex.rd             = rd;


### PR DESCRIPTION
modifying the lw_stall so that it does not misread a CSR into load; adding csr_stall for CSR-to-CSR hazard (two CSR go back to back and the second one reading the old value)