### PR TITLE
Add m extension control and hazard

### DIFF
--- a/src/ext/m/decoder.sv
+++ b/src/ext/m/decoder.sv
@@ -8,23 +8,23 @@ module ext__m__decoder
     ( input [2:0] funct3
     , input [6:0] funct7
     , input opcode_t opcode
-    , output logic is_mul
-    , output logic is_div
 `ifdef UTOSS_RISCV__MUL_ENABLED
+    , output logic is_mul
     , output ext__m__types::m_mul_control_t mul_control
 `endif
 `ifdef UTOSS_RISCV__DIV_ENABLED
+    , output logic is_div
     , output ext__m__types::m_div_control_t div_control
 `endif
     );
 
     always @(*) begin
-        is_mul = 1'b0;
-        is_div = 1'b0;
 `ifdef UTOSS_RISCV__MUL_ENABLED
+        is_mul = 1'b0;
         mul_control = ext__m__types::M_ALU_CTRL__MUL_NONE;
 `endif
 `ifdef UTOSS_RISCV__DIV_ENABLED
+        is_div = 1'b0;
         div_control = ext__m__types::M_ALU_CTRL__DIV_NONE;
 `endif
 

--- a/src/hazard_unit.sv
+++ b/src/hazard_unit.sv
@@ -15,10 +15,20 @@ module hazard_unit
   , input  reg_t      rs2_d
   , input  reg_t      rd_e
   , input  pc_src_t pc_src_e
+
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  , input  logic div_e
+  , input  logic div_busy_e
+  , input  logic div_done_e
+  , output logic div_start_e
+  , output logic div_cancel_e
+`endif
+
   , output hazard_forward_a_t forward_a_e
   , output hazard_forward_b_t forward_b_e
   , output logic stall_f
   , output logic stall_d
+  , output logic stall_e
   , output logic flush_f
   , output logic flush_d
   , output logic flush_e
@@ -48,10 +58,21 @@ module hazard_unit
 
   logic lw_stall;
 
-  //Stall when a load hazard occurs
+  // Stall when a load hazard occurs
   assign lw_stall = result_src_e_0 && ((rs1_d == rd_e) || (rs2_d == rd_e)) && (rd_e != 5'd0);
+
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  wire div_stall;
+  assign div_stall = div_e && !div_done_e;
+
+  assign stall_f = lw_stall || div_stall;
+  assign stall_d = lw_stall || div_stall;
+  assign stall_e = div_stall;
+`else
   assign stall_f = lw_stall;
   assign stall_d = lw_stall;
+  assign stall_e = 1'b0;
+`endif
 
   //Flush when a control hazard occurs; we need to flush one cycle later than we discover the
   // control hazard; this is due to synchronous memory making the instruction available one cycle
@@ -65,5 +86,10 @@ module hazard_unit
   assign flush_f = control_hazard;
   assign flush_d = control_hazard;
   assign flush_e = lw_stall || control_hazard;
+
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  assign div_start_e = div_e && !div_busy_e && !div_done_e;
+  assign div_cancel_e = control_hazard;
+`endif
 
 endmodule

--- a/src/interfaces/id_to_ex_if.svh
+++ b/src/interfaces/id_to_ex_if.svh
@@ -3,6 +3,9 @@
 
 `include "src/headers/params.svh"
 `include "src/headers/types.svh"
+`ifdef UTOSS_RISCV__ANY_M
+`include "src/ext/m/types.svh"
+`endif
 
 typedef struct packed {
   alu_src_a_t   alu_src_a;

--- a/src/modules/Instruction_Decode/Instruction_Decode.sv
+++ b/src/modules/Instruction_Decode/Instruction_Decode.sv
@@ -171,12 +171,12 @@ module Instruction_Decode
     ( .funct3      ( funct3      )
     , .funct7      ( funct7      )
     , .opcode      ( opcode      )
-    , .is_mul      ( is_mul      )
-    , .is_div      ( is_div      )
 `ifdef UTOSS_RISCV__MUL_ENABLED
+    , .is_mul      ( is_mul      )
     , .mul_control ( mul_control )
 `endif
 `ifdef UTOSS_RISCV__DIV_ENABLED
+    , .is_div      ( is_div      )
     , .div_control ( div_control )
 `endif
     );

--- a/src/stages/decode_stage.sv
+++ b/src/stages/decode_stage.sv
@@ -82,14 +82,10 @@ module decode_stage
     , .rs2             ( rs2              )
 `ifdef UTOSS_RISCV__MUL_ENABLED
     , .is_mul          ( is_mul           )
-`endif
-`ifdef UTOSS_RISCV__DIV_ENABLED
-    , .is_div          ( is_div           )
-`endif
-`ifdef UTOSS_RISCV__MUL_ENABLED
     , .mul_control     ( mul_control      )
 `endif
 `ifdef UTOSS_RISCV__DIV_ENABLED
+    , .is_div          ( is_div           )
     , .div_control     ( div_control      )
 `endif
 `ifdef UTOSS_RISCV_ENABLE_B_EXT

--- a/src/stages/execute_stage.sv
+++ b/src/stages/execute_stage.sv
@@ -6,13 +6,24 @@
 
 module execute_stage
   ( input id_to_ex_t id_to_ex
-
+`ifdef UTOSS_RISCV__ANY_M
+  , input logic clk
+  , input logic reset
+`endif
   , input hazard_forward_a_t hz_forward_a
   , input hazard_forward_b_t hz_forward_b
 
   , input data_t wb_result
   , input data_t mem_alu_result
 
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  /* verilator lint_off UNUSEDSIGNAL */
+  , input logic div_start_e
+  /* verilator lint_on UNUSEDSIGNAL */
+  , input logic div_cancel_e
+  , output logic div_busy_e
+  , output logic div_done_e
+`endif
   , output ex_to_if_t ex_to_if
   , output ex_to_mem_t ex_to_mem
   );
@@ -22,6 +33,16 @@ module execute_stage
   data_t safe_rd1; // hazard-safe version of rd1
   data_t safe_rd2; // hazard-safe version of rd2
   data_t alu_result;
+`ifdef UTOSS_RISCV__MUL_ENABLED
+  data_t mul_result;
+  /* verilator lint_off UNUSEDSIGNAL */
+  logic mul_done;
+  /* verilator lint_on UNUSEDSIGNAL */
+`endif
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  data_t div_result;
+`endif
+  data_t final_result;
   logic zero_flag;
 
 `ifdef UTOSS_RISCV_ENABLE_B_EXT
@@ -71,6 +92,42 @@ module execute_stage
     , .out            ( alu_result_base          )
     , .zeroE          ( zero_flag_base           ) //added bases for local
     );
+
+`ifdef UTOSS_RISCV__MUL_ENABLED
+  MUL mul
+    ( .clk      ( clk                  )
+    , .rst_n    ( ~reset               )
+    , .start_i  ( id_to_ex.is_mul      )
+    , .rs1_i    ( alu_input_a          )
+    , .rs2_i    ( alu_input_b          )
+    , .op_i     ( id_to_ex.mul_control )
+    , .result_o ( mul_result           )
+    , .ready_o  ( mul_done             )
+    );
+`endif
+
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  DIV div
+    ( .clk       ( clk                  )
+    , .rst_n     ( ~reset               )
+    , .start_i   ( div_start_e          )
+    , .op_i      ( id_to_ex.div_control )
+    , .rs1_i     ( alu_input_a          )
+    , .rs2_i     ( alu_input_b          )
+    , .result_o  ( div_result           )
+    , .ready_o   ( div_done_e           )
+    , .busy_o    ( div_busy_e           )
+    );
+`endif
+
+  assign final_result =
+`ifdef UTOSS_RISCV__MUL_ENABLED
+    id_to_ex.is_mul ? mul_result :
+`endif
+`ifdef UTOSS_RISCV__DIV_ENABLED
+    id_to_ex.is_div ? div_result :
+`endif
+    alu_result;
 
 `ifdef UTOSS_RISCV_ENABLE_B_EXT
   zbb u_zbb
@@ -144,7 +201,7 @@ assign zero_flag  = zero_flag_base;
   assign ex_to_mem.funct3       = id_to_ex.funct3;
   assign ex_to_mem.write_data_e = safe_rd2;
   assign ex_to_mem.rd           = id_to_ex.rd;
-  assign ex_to_mem.alu_result   = alu_result;
+  assign ex_to_mem.alu_result   = final_result;
   assign ex_to_mem.pc_cur       = id_to_ex.pc_cur;
   assign ex_to_mem.pc_plus_4    = id_to_ex.pc_plus_4;
   assign ex_to_if.imm_ext       = id_to_ex.imm_ext;
@@ -152,5 +209,10 @@ assign zero_flag  = zero_flag_base;
   assign ex_to_if.pc_target     = pc_target;
   assign ex_to_if.pc_old        = id_to_ex.pc_cur;
 
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  wire unused = &{id_to_ex.rs1, id_to_ex.rs2, div_cancel_e};
+`else
   wire unused = &{id_to_ex.rs1, id_to_ex.rs2};
+`endif
+
 endmodule

--- a/src/utoss_riscv.sv
+++ b/src/utoss_riscv.sv
@@ -88,13 +88,26 @@ module utoss_riscv
   // execute stage begin (@MSh-786 and tandr3w)
 
   always_ff @ (posedge clk)
-    if (reset)        id_to_ex_reg <= '0;
-    else if (flush_e) id_to_ex_reg <= '0;
-    else              id_to_ex_reg <= id_to_ex_out;
+    if (reset)         id_to_ex_reg <= '0;
+    else if (flush_e)  id_to_ex_reg <= '0;
+    else if (!stall_e) id_to_ex_reg <= id_to_ex_out;
 
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  logic div_busy_e, div_done_e;
+`endif
   execute_stage u_execute_stage
-    ( .id_to_ex ( id_to_ex_reg )
+    ( .id_to_ex     ( id_to_ex_reg    )
+`ifdef UTOSS_RISCV__ANY_M
+    , .clk          ( clk             )
+    , .reset        ( reset           )
+`endif
+`ifdef UTOSS_RISCV__DIV_ENABLED
+    , .div_start_e  ( div_start_e     )
+    , .div_cancel_e ( div_cancel_e    )
+    , .div_busy_e   ( div_busy_e      )
+    , .div_done_e   ( div_done_e      )
 
+`endif
     , .hz_forward_a ( hz_forward_a )
     , .hz_forward_b ( hz_forward_b )
 
@@ -110,8 +123,9 @@ module utoss_riscv
   // memory stage begin (@Invisipac)
 
   always_ff @ (posedge clk)
-    if (reset) ex_to_mem_reg <= '0;
-    else       ex_to_mem_reg <= ex_to_mem_out;
+    if (reset)        ex_to_mem_reg <= '0;
+    else if (stall_e) ex_to_mem_reg <= '0;
+    else              ex_to_mem_reg <= ex_to_mem_out;
 
   memory_stage u_memory_stage
   ( .ex_to_mem ( ex_to_mem_reg )
@@ -146,7 +160,10 @@ module utoss_riscv
 
   hazard_forward_a_t hz_forward_a;
   hazard_forward_b_t hz_forward_b;
-  logic stall_f, stall_d, flush_f, flush_d, flush_e;
+  logic stall_f, stall_d, stall_e, flush_f, flush_d, flush_e;
+`ifdef UTOSS_RISCV__DIV_ENABLED
+  logic div_start_e, div_cancel_e;
+`endif
 
   hazard_unit u_hazard_unit
     ( .clk ( clk )
@@ -162,14 +179,21 @@ module utoss_riscv
     , .reg_write_w  ( mem_to_wb_reg.reg_write )
     , .result_src_e ( id_to_ex_reg.result_src )
     , .pc_src_e     ( ex_to_if_out.pc_src     )
-
-    , .forward_a_e ( hz_forward_a )
-    , .forward_b_e ( hz_forward_b )
-    , .stall_f    ( stall_f       )
-    , .stall_d    ( stall_d       )
-    , .flush_f    ( flush_f       )
-    , .flush_d    ( flush_d       )
-    , .flush_e    ( flush_e       )
+`ifdef UTOSS_RISCV__DIV_ENABLED
+    , .div_e        ( id_to_ex_reg.is_div     )
+    , .div_busy_e   ( div_busy_e              )
+    , .div_done_e   ( div_done_e              )
+    , .div_start_e  ( div_start_e             )
+    , .div_cancel_e ( div_cancel_e            )
+`endif
+    , .forward_a_e  ( hz_forward_a  )
+    , .forward_b_e  ( hz_forward_b  )
+    , .stall_f      ( stall_f       )
+    , .stall_d      ( stall_d       )
+    , .stall_e      ( stall_e       )
+    , .flush_f      ( flush_f       )
+    , .flush_d      ( flush_d       )
+    , .flush_e      ( flush_e       )
     );
 
   // hazard module end


### PR DESCRIPTION
Close #245 
Updated hazard unit to allow for DIV
Updated execute to select the MUL or DIV module instead of the ALU when needed
Added mul and div instructions to the interface between decode and execute

Note that I didn't actually use div_cancel since it wasn't in the diagram in the planning doc. Also, it seems unnececssary after thinking about it a little? Since a branch instruction should never be in ex at the same time as a div.

I also assumed that the modules would look like the diagrams, and I might've accidentally done some of the integration work as well since I didn't really know how to separate it