### PR TITLE
Extract extend module from instruction decoder

### DIFF
--- a/envs/de1-soc/quartus/utoss-risc-v.qsf
+++ b/envs/de1-soc/quartus/utoss-risc-v.qsf
@@ -323,6 +323,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE ../../../src/interfaces/if_to_id_
 set_global_assignment -name SYSTEMVERILOG_FILE ../../../src/interfaces/mem_to_wb_if.svh
 set_global_assignment -name SYSTEMVERILOG_FILE ../../../src/modules/ALU_ALUdecoder/ALU.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ../../../src/modules/ALU_ALUdecoder/ALUdecoder.sv
+set_global_assignment -name SYSTEMVERILOG_FILE ../../../src/modules/Instruction_Decode/extend.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ../../../src/modules/Instruction_Decode/Instruction_Decode.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ../../../src/modules/Instruction_Decode/MemoryLoader.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ../../../src/modules/Instruction_Decode/registerFile.sv

--- a/src/modules/Instruction_Decode/Instruction_Decode.sv
+++ b/src/modules/Instruction_Decode/Instruction_Decode.sv
@@ -118,21 +118,11 @@ module Instruction_Decode
     endcase
   end
 
-  // case statement for choosing 32-bit immediate format; based on opcode
-    // this is essentially the extend module of the processor
-  always @(*) begin
-    case (opcode)
-      OPCODE_OP_IMM : imm_ext = {{20{instr[31]}}, instr[31:20]};
-      OPCODE_LOAD  : imm_ext = {{20{instr[31]}}, instr[31:20]};
-      OPCODE_JALR : imm_ext = {{20{instr[31]}}, instr[31:20]};
-      OPCODE_STORE       : imm_ext = {{20{instr[31]}}, instr[31:25], instr[11:7]};
-      OPCODE_BRANCH       : imm_ext = {{20{instr[31]}}, instr[7], instr[30:25], instr[11:8], 1'b0};
-      OPCODE_JAL       : imm_ext = {{12{instr[31]}}, instr[19:12], instr[20], instr[30:21], 1'b0};
-      OPCODE_AUIPC  : imm_ext = {instr[31:12], 12'h000};
-      OPCODE_LUI  : imm_ext = {instr[31:12], 12'h000};
-      default:     imm_ext = 32'b0;
-    endcase
-  end
+  extend u_extend
+    ( .instr   ( instr[31:7] )
+    , .opcode  ( opcode      )
+    , .imm_ext ( imm_ext     )
+    );
 
   //Instantiate ALU Decoder module
 

--- a/src/modules/Instruction_Decode/extend.sv
+++ b/src/modules/Instruction_Decode/extend.sv
@@ -8,18 +8,15 @@ module extend
   , output imm_t    imm_ext
   );
 
-  always_comb begin
+  always_comb
     case (opcode)
-      OPCODE_OP_IMM,
-      OPCODE_LOAD,
-      OPCODE_JALR:   imm_ext = {{20{instr[31]}}, instr[31:20]};
+      OPCODE_OP_IMM, OPCODE_LOAD, OPCODE_JALR:
+        imm_ext = {{20{instr[31]}}, instr[31:20]};
       OPCODE_STORE:  imm_ext = {{20{instr[31]}}, instr[31:25], instr[11:7]};
       OPCODE_BRANCH: imm_ext = {{20{instr[31]}}, instr[7], instr[30:25], instr[11:8], 1'b0};
       OPCODE_JAL:    imm_ext = {{12{instr[31]}}, instr[19:12], instr[20], instr[30:21], 1'b0};
-      OPCODE_AUIPC,
-      OPCODE_LUI:    imm_ext = {instr[31:12], 12'b0};
+      OPCODE_AUIPC, OPCODE_LUI: imm_ext = {instr[31:12], 12'b0};
       default:       imm_ext = 32'b0;
     endcase
-  end
 
 endmodule

--- a/src/modules/Instruction_Decode/extend.sv
+++ b/src/modules/Instruction_Decode/extend.sv
@@ -1,0 +1,25 @@
+`include "src/headers/params.svh"
+`include "src/headers/types.svh"
+`include "src/timescale.svh"
+
+module extend
+  ( input  wire [31:7] instr
+  , input  opcode_t opcode
+  , output imm_t    imm_ext
+  );
+
+  always_comb begin
+    case (opcode)
+      OPCODE_OP_IMM,
+      OPCODE_LOAD,
+      OPCODE_JALR:   imm_ext = {{20{instr[31]}}, instr[31:20]};
+      OPCODE_STORE:  imm_ext = {{20{instr[31]}}, instr[31:25], instr[11:7]};
+      OPCODE_BRANCH: imm_ext = {{20{instr[31]}}, instr[7], instr[30:25], instr[11:8], 1'b0};
+      OPCODE_JAL:    imm_ext = {{12{instr[31]}}, instr[19:12], instr[20], instr[30:21], 1'b0};
+      OPCODE_AUIPC,
+      OPCODE_LUI:    imm_ext = {instr[31:12], 12'b0};
+      default:       imm_ext = 32'b0;
+    endcase
+  end
+
+endmodule

--- a/test/extend_tb.sv
+++ b/test/extend_tb.sv
@@ -25,34 +25,33 @@ module extend_tb;
     instr = test_instr;
     #1;
     assert (imm_ext == expected)
-      else $fatal(1, "opcode=%b instr=%h: expected imm_ext=%h, got %h",
-                  opcode, instr, expected, imm_ext);
+      else $fatal(1, "opcode=%b instr=%h: expected imm_ext=%h, got %h", opcode, instr, expected, imm_ext);
   endtask
 
   initial begin
     // I-type: positive and negative immediates.
     check_imm(OPCODE_OP_IMM, 32'h1230_0093, 32'h0000_0123);
-    check_imm(OPCODE_LOAD,   32'hfff0_2083, 32'hffff_ffff);
-    check_imm(OPCODE_JALR,   32'h8000_0067, 32'hffff_f800);
+    check_imm(OPCODE_LOAD, 32'hfff0_2083, 32'hffff_ffff);
+    check_imm(OPCODE_JALR, 32'h8000_0067, 32'hffff_f800);
 
     // S-type: immediate bits are split between instr[31:25] and instr[11:7].
-    check_imm(OPCODE_STORE,  32'h7e00_0fa3, 32'h0000_07ff);
-    check_imm(OPCODE_STORE,  32'h8000_0023, 32'hffff_f800);
+    check_imm(OPCODE_STORE, 32'h7e00_0fa3, 32'h0000_07ff);
+    check_imm(OPCODE_STORE, 32'h8000_0023, 32'hffff_f800);
 
     // B-type: immediate is sign-extended and its least-significant bit is zero.
     check_imm(OPCODE_BRANCH, 32'h7e00_0fe3, 32'h0000_0ffe);
     check_imm(OPCODE_BRANCH, 32'h8000_0063, 32'hffff_f000);
 
     // J-type: immediate is sign-extended and its least-significant bit is zero.
-    check_imm(OPCODE_JAL,    32'h7ff0_00ef, 32'h0000_0ffe);
-    check_imm(OPCODE_JAL,    32'h8000_006f, 32'hfff0_0000);
+    check_imm(OPCODE_JAL, 32'h7ff0_00ef, 32'h0000_0ffe);
+    check_imm(OPCODE_JAL, 32'h8000_006f, 32'hfff0_0000);
 
     // U-type: the upper 20 instruction bits are preserved.
-    check_imm(OPCODE_LUI,    32'habcde_0b7, 32'habcde_000);
-    check_imm(OPCODE_AUIPC,  32'h12345_097, 32'h12345_000);
+    check_imm(OPCODE_LUI, 32'habcde_0b7, 32'habcde_000);
+    check_imm(OPCODE_AUIPC, 32'h12345_097, 32'h12345_000);
 
     // Opcodes without an immediate produce zero.
-    check_imm(OPCODE_OP,     32'hffff_ffff, 32'b0);
+    check_imm(OPCODE_OP, 32'hffff_ffff, 32'b0);
   end
 
   `SETUP_VCD_DUMP(extend_tb)

--- a/test/extend_tb.sv
+++ b/test/extend_tb.sv
@@ -1,0 +1,60 @@
+`include "src/timescale.svh"
+
+`include "src/headers/params.svh"
+`include "src/headers/types.svh"
+`include "test/utils.svh"
+
+module extend_tb;
+
+  instr_t  instr;
+  opcode_t opcode;
+  imm_t    imm_ext;
+
+  extend uut
+    ( .instr   ( instr[31:7] )
+    , .opcode  ( opcode      )
+    , .imm_ext ( imm_ext     )
+    );
+
+  task automatic check_imm
+    ( input opcode_t test_opcode
+    , input instr_t  test_instr
+    , input imm_t    expected
+    );
+    opcode = test_opcode;
+    instr = test_instr;
+    #1;
+    assert (imm_ext == expected)
+      else $fatal(1, "opcode=%b instr=%h: expected imm_ext=%h, got %h",
+                  opcode, instr, expected, imm_ext);
+  endtask
+
+  initial begin
+    // I-type: positive and negative immediates.
+    check_imm(OPCODE_OP_IMM, 32'h1230_0093, 32'h0000_0123);
+    check_imm(OPCODE_LOAD,   32'hfff0_2083, 32'hffff_ffff);
+    check_imm(OPCODE_JALR,   32'h8000_0067, 32'hffff_f800);
+
+    // S-type: immediate bits are split between instr[31:25] and instr[11:7].
+    check_imm(OPCODE_STORE,  32'h7e00_0fa3, 32'h0000_07ff);
+    check_imm(OPCODE_STORE,  32'h8000_0023, 32'hffff_f800);
+
+    // B-type: immediate is sign-extended and its least-significant bit is zero.
+    check_imm(OPCODE_BRANCH, 32'h7e00_0fe3, 32'h0000_0ffe);
+    check_imm(OPCODE_BRANCH, 32'h8000_0063, 32'hffff_f000);
+
+    // J-type: immediate is sign-extended and its least-significant bit is zero.
+    check_imm(OPCODE_JAL,    32'h7ff0_00ef, 32'h0000_0ffe);
+    check_imm(OPCODE_JAL,    32'h8000_006f, 32'hfff0_0000);
+
+    // U-type: the upper 20 instruction bits are preserved.
+    check_imm(OPCODE_LUI,    32'habcde_0b7, 32'habcde_000);
+    check_imm(OPCODE_AUIPC,  32'h12345_097, 32'h12345_000);
+
+    // Opcodes without an immediate produce zero.
+    check_imm(OPCODE_OP,     32'hffff_ffff, 32'b0);
+  end
+
+  `SETUP_VCD_DUMP(extend_tb)
+
+endmodule


### PR DESCRIPTION
## What changed

- extracted immediate-generation logic into a standalone `extend` module
- kept the `Instruction_Decode` interface and behavior unchanged
- added a dedicated testbench for I, S, B, J, and U-type immediates

## Why

This keeps immediate generation separate from instruction decoding and brings the implementation closer to the canonical processor structure described in the project issue.

## Impact

This is a structural refactor. Existing decoder consumers continue to receive the same `imm_ext` output.

## Validation

- all 10 SystemVerilog testbenches pass with Verilator
- the new `extend_tb` covers positive and negative immediates, alignment bits, U-type immediates, and the default case
- RV32I and RV32IB Verilator lint/elaboration pass for the changed design (excluding a pre-existing `UNUSEDLOOP` warning in `zbb.sv`)

Closes #186
